### PR TITLE
added "defer" attribute to application's js

### DIFF
--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -18,7 +18,7 @@
       <link rel="stylesheet" href={asset_path(@conn, "css/fonts.css")}/>
     <% end %>
     <%= if path = storybook_js_path(@conn) do %>
-      <script phx-track-static type="text/javascript" src={application_static_path( path)}></script>
+      <script phx-track-static type="text/javascript" defer src={application_static_path(path)}></script>
     <% end %>
     <script type="text/javascript" src={asset_path(@conn, "js/app.js")}></script>  
 


### PR DESCRIPTION
Currently it is not possible to use javascript code that depends on certain DOM characteristics because the user's script tag is executed before the creation of the body.

By adding the `defer` attribute, the javascript file will be download along with the rendering of the document and executed after the document is rendered.

This allows the use case of using JS libraries that use the DOM characteristics in order to provide functionality, such as a script that selects rendered elements with `ripple="true"` and provide them this functionality. 