### PR TITLE
Add LiveSocketOptions to support alpine.js

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,6 +29,7 @@ let liveSocket = new LiveSocket(socketPath, Socket, {
       extra: window.storybook.Params,
     };
   },
+  ...window.storybook.LiveSocketOptions
 });
 
 liveSocket.connect();

--- a/assets/js/iframe.js
+++ b/assets/js/iframe.js
@@ -25,6 +25,7 @@ let liveSocket = new LiveSocket(socketPath, Socket, {
       _csrf_token: csrfToken,
     };
   },
+  ...window.storybook.LiveSocketOptions
 });
 
 liveSocket.connect();

--- a/priv/templates/phx.gen.storybook/storybook.js
+++ b/priv/templates/phx.gen.storybook/storybook.js
@@ -9,3 +9,27 @@
 // (function () {
 //   window.storybook = { Hooks, Params, Uploaders };
 // })();
+
+
+// If your components require alpinejs, you'll need to start
+// alpine after the DOM is loaded and pass in an onBeforeElUpdated
+// 
+// import Alpine from 'alpinejs'
+// window.Alpine = Alpine
+// document.addEventListener('DOMContentLoaded', () => {
+//   window.Alpine.start();
+// });
+
+// (function () {
+//   window.storybook = {
+//     LiveSocketOptions: {
+//       dom: {
+//         onBeforeElUpdated(from, to) {
+//           if (from._x_dataStack) {
+//             window.Alpine.clone(from, to)
+//           }
+//         }
+//       }
+//     }
+//   };
+// })();


### PR DESCRIPTION
Currently, you can customize the LiveSocket configuration using `window.storybook.Hooks`, `window.storybook.Params`, and `window.storybook.Uploaders`; however, there's no way to set other options like `bindingPrefix` and `dom`.  Specifically, you need `dom` for components that use alpine.js.

This PR adds `window.storybook.LiveSocketOptions` as a generic way to pass options into LiveSocket configuration.

Additionally, I've updated the storybook.js template comments to explain how to use storybook with components that rely on alpine.js

I've tested this in my app with alpine.js. There are no breaking changes--if `LiveSocketOptions` is undefined, there is no change in functionality.