### PR TITLE
phx.gen.storybook alias to match storybook tailwind profile

### DIFF
--- a/lib/mix/tasks/phx.gen.storybook.ex
+++ b/lib/mix/tasks/phx.gen.storybook.ex
@@ -267,7 +267,7 @@ defmodule Mix.Tasks.Phx.Gen.Storybook do
           ...,
           "assets.deploy": [
             ...
-            #{IO.ANSI.bright()}"tailwind default --minify",#{IO.ANSI.reset()}
+            #{IO.ANSI.bright()}"tailwind storybook --minify",#{IO.ANSI.reset()}
             "phx.digest"
           ]
         ]


### PR DESCRIPTION
The `default` tailwind profile should already be there from the `mix phx.new`.  The generator has instructions to make a new `storybook` tailwind profile and that tailwind profile build command is what needs to be added to the `assets.deploy`

When I followed the instructions as printed when I did a release Phoenix was throwing a 404 on `/assets/storybook.css` because it wasn't being built.