### PR TITLE
Adding assets url as a configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ defmodule MyAppWeb.Storybook do
     # by your own application endpoint.
     css_path: "/assets/storybook.css",
 
+    # js_url: "localhost:4000/assets/storybook.js",
+    # css_url: "localhost:4000/assets/storybook.css",
+
     # This CSS class will be put on storybook container elements where your own styles should
     # prevail. See the `guides/sandboxing.md` guide for more details.
     sandbox_class: "my-app-sandbox",

--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -20,11 +20,17 @@
     <%= if path = storybook_js_path(@conn) do %>
       <script phx-track-static type="text/javascript" src={application_static_path(path)}></script>
     <% end %>
+    <%= if url = storybook_js_url(@conn) do %>
+      <script phx-track-static type="text/javascript" src={url}></script>
+    <% end %>
     <script type="text/javascript" src={asset_path(@conn, "js/app.js")}></script>  
 
     <link rel="stylesheet" href={asset_path(@conn, "css/app.css")}/>
     <%= if path = storybook_css_path(@conn) do %>
       <link phx-track-static rel="stylesheet" href={application_static_path(path)}/>
+    <% end %>
+    <%= if url = storybook_css_url(@conn) do %>
+      <link rel="stylesheet" href={url}/>
     <% end %>
     <style><%= raw(makeup_stylesheet(@conn)) %></style>
   </head>

--- a/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
@@ -23,7 +23,6 @@
     <%= if url = storybook_css_url(@conn) do %>
       <link rel="stylesheet" href={url}/>
     <% end %>
-    <script type="module" src="http://localhost:8080/@vite/client">
   </script>
   </head>
   

--- a/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
@@ -5,6 +5,9 @@
     <%= if path = storybook_js_path(@conn) do %>
       <script phx-track-static type="text/javascript" src={application_static_path(path)}></script>
     <% end %>
+    <%= if url = storybook_js_url(@conn) do %>
+      <script phx-track-static type="text/javascript" src={url}></script>
+    <% end %>
     <script type="text/javascript" src={asset_path(@conn, "js/iframe.js")}></script>  
 
     <%= if fa_kit_id = fa_kit_id(@conn) do %>
@@ -17,6 +20,11 @@
     <%= if path = storybook_css_path(@conn) do %>
       <link phx-track-static rel="stylesheet" href={application_static_path(path)}/>
     <% end %>
+    <%= if url = storybook_css_url(@conn) do %>
+      <link rel="stylesheet" href={url}/>
+    <% end %>
+    <script type="module" src="http://localhost:8080/@vite/client">
+  </script>
   </head>
   
   <% container = if assigns[:story], do: assigns[:story].container(), else: :div %>

--- a/lib/phoenix_storybook/views/layout_view.ex
+++ b/lib/phoenix_storybook/views/layout_view.ex
@@ -48,6 +48,9 @@ defmodule PhoenixStorybook.LayoutView do
   defp storybook_css_path(conn), do: storybook_setting(conn, :css_path)
   defp storybook_js_path(conn), do: storybook_setting(conn, :js_path)
 
+  defp storybook_js_url(conn), do: storybook_setting(conn, :js_url)
+  defp storybook_css_url(conn), do: storybook_setting(conn, :css_url)
+
   defp title(conn_or_socket), do: storybook_setting(conn_or_socket, :title, "Live Storybook")
 
   defp title_prefix(conn_or_socket) do


### PR DESCRIPTION
This merge request adds a possibility to define assets URLs. We’re using Vite server to serve our assets, while developing locally. It means our assets are served on a different URL, compared to our developed application.

I have added as a configuration following settings: 
* js_url
* css_url

This was the simplest solution that made Storybook to work locally. Let me know, if you have any suggestion on better resolution of this, taking into account existence of: `css_path` and `js_path` settings.

I'll be happy to contribute, so that it is possible for us to be up-to-date with newer releases of Phoenix Storybook.
