### PR TITLE
Fix CSP support

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -29,16 +29,18 @@
       "extraneous": true
     },
     "../deps/phoenix": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "1.7.7",
+      "dev": true,
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1",
+      "version": "3.3.1",
       "dev": true
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1",
-      "dev": true
+      "version": "0.18.18",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",

--- a/lib/phoenix_storybook/mount.ex
+++ b/lib/phoenix_storybook/mount.ex
@@ -8,7 +8,8 @@ defmodule PhoenixStorybook.Mount do
       assign(socket,
         backend_module: Map.fetch!(session, "backend_module"),
         root_path: Map.fetch!(session, "root_path"),
-        assets_path: Map.fetch!(session, "assets_path")
+        assets_path: Map.fetch!(session, "assets_path"),
+        csp_nonces: Map.fetch!(session, "csp_nonces")
       )
 
     {:cont, socket}

--- a/lib/phoenix_storybook/templates/layout/_favicon.html.heex
+++ b/lib/phoenix_storybook/templates/layout/_favicon.html.heex
@@ -1,7 +1,10 @@
-<link rel="apple-touch-icon" sizes="180x180" href={asset_path(@conn, "favicon/apple-touch-icon.png")}>
-<link rel="icon" type="image/png" sizes="32x32" href={asset_path(@conn, "favicon/favicon-32x32.png")}>
-<link rel="icon" type="image/png" sizes="16x16" href={asset_path(@conn, "favicon/favicon-16x16.png")}>
+<!-- All the nonces here are giving me issues, as they still return errors similar to:
+"Refused to load the image 'http://localhost:4000/storybook/assets/favicon/apple-touch-icon.png'
+because it violates the following Content Security Policy directive:" -->
+<link nonce={csp_nonce(@conn, :img)} rel="apple-touch-icon" sizes="180x180" href={asset_path(@conn, "favicon/apple-touch-icon.png")}>
+<link nonce={csp_nonce(@conn, :img)} rel="icon" type="image/png" sizes="32x32" href={asset_path(@conn, "favicon/favicon-32x32.png")}>
+<link nonce={csp_nonce(@conn, :img)} rel="icon" type="image/png" sizes="16x16" href={asset_path(@conn, "favicon/favicon-16x16.png")}>
 <link rel="manifest" href={asset_path(@conn, "favicon/site.webmanifest")}>
-<link rel="mask-icon" href={asset_path(@conn, "favicon/safari-pinned-tab.svg")} color="#4F46E5">
+<link nonce={csp_nonce(@conn, :img)} rel="mask-icon" href={asset_path(@conn, "favicon/safari-pinned-tab.svg")} color="#4F46E5">
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -55,7 +55,7 @@
 
 <div class="lsb lsb-absolute lsb-opacity-20 lsb-top-0 lsb-inset-x-0 lsb-flex lsb-justify-center lsb-overflow-hidden lsb-pointer-events-none">
   <div class="lsb lsb-w-[108rem] lsb-flex-none lsb-flex lsb-justify-end">
-    <img src={asset_path(@socket, "images/background.png")} class="lsb lsb-w-[71.75rem] lsb-flex-none lsb-max-w-none"/>
+    <img nonce={csp_nonce(@csp_nonces, :img)} src={asset_path(@socket, "images/background.png")} class="lsb lsb-w-[71.75rem] lsb-flex-none lsb-max-w-none"/>
   </div>
 </div>
 

--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -26,7 +26,9 @@
     <%= if path = storybook_css_path(@conn) do %>
       <link nonce={csp_nonce(@conn, :style)} phx-track-static rel="stylesheet" href={application_static_path(path)}/>
     <% end %>
-    <style nonce={csp_nonce(@conn, :style)} raw(makeup_stylesheet(@conn)) %></style>
+    <style nonce={csp_nonce(@conn, :style)}>
+      <%= raw(makeup_stylesheet(@conn))%>
+    </style>
   </head>
 
   <body class={["lsb lsb-max-w-full lsb-overflow-hidden", wait_for_icons?(@conn)]}>

--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -13,20 +13,20 @@
     </.live_title>
 
     <%= if fa_kit_id = fa_kit_id(@conn) do %>
-      <script defer src={"https://kit.fontawesome.com/#{fa_kit_id}.js"} crossorigin="anonymous"></script>
+      <script nonce={csp_nonce(@conn, :script)} defer src={"https://kit.fontawesome.com/#{fa_kit_id}.js"} crossorigin="anonymous"></script>
     <% else %>
-      <link rel="stylesheet" href={asset_path(@conn, "css/fonts.css")}/>
+      <link nonce={csp_nonce(@conn, :style)} rel="stylesheet" href={asset_path(@conn, "css/fonts.css")}/>
     <% end %>
     <%= if path = storybook_js_path(@conn) do %>
-      <script phx-track-static type="text/javascript" src={application_static_path(path)}></script>
+      <script nonce={csp_nonce(@conn, :script)} phx-track-static type="text/javascript" src={application_static_path(path)}></script>
     <% end %>
-    <script type="text/javascript" src={asset_path(@conn, "js/app.js")}></script>  
+    <script nonce={csp_nonce(@conn, :script)} type="text/javascript" src={asset_path(@conn, "js/app.js")}></script>  
 
-    <link rel="stylesheet" href={asset_path(@conn, "css/app.css")}/>
+    <link nonce={csp_nonce(@conn, :style)} rel="stylesheet" href={asset_path(@conn, "css/app.css")}/>
     <%= if path = storybook_css_path(@conn) do %>
-      <link phx-track-static rel="stylesheet" href={application_static_path(path)}/>
+      <link nonce={csp_nonce(@conn, :style)} phx-track-static rel="stylesheet" href={application_static_path(path)}/>
     <% end %>
-    <style><%= raw(makeup_stylesheet(@conn)) %></style>
+    <style nonce={csp_nonce(@conn, :style)} raw(makeup_stylesheet(@conn)) %></style>
   </head>
 
   <body class={["lsb lsb-max-w-full lsb-overflow-hidden", wait_for_icons?(@conn)]}>

--- a/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
@@ -3,19 +3,19 @@
   <head>
     <%= csrf_meta_tag() %>
     <%= if path = storybook_js_path(@conn) do %>
-      <script phx-track-static type="text/javascript" src={application_static_path(path)}></script>
+      <script nonce={csp_nonce(@conn, :script)} phx-track-static type="text/javascript" src={application_static_path(path)}></script>
     <% end %>
-    <script type="text/javascript" src={asset_path(@conn, "js/iframe.js")}></script>  
+    <script nonce={csp_nonce(@conn, :script)} type="text/javascript" src={asset_path(@conn, "js/iframe.js")}></script>  
 
     <%= if fa_kit_id = fa_kit_id(@conn) do %>
-      <script defer src={"https://kit.fontawesome.com/#{fa_kit_id}.js"} crossorigin="anonymous"></script>
+      <script nonce={csp_nonce(@conn, :script)} defer src={"https://kit.fontawesome.com/#{fa_kit_id}.js"} crossorigin="anonymous"></script>
     <% else %>
-      <link rel="stylesheet" href={asset_path(@conn, "css/fonts.css")}/>
+      <link rel="stylesheet" nonce={csp_nonce(@conn, :style)} href={asset_path(@conn, "css/fonts.css")}/>
     <% end %>
 
-    <link rel="stylesheet" href={asset_path(@conn, "css/app.css")}/>
+    <link rel="stylesheet" nonce={csp_nonce(@conn, :style)} href={asset_path(@conn, "css/app.css")}/>
     <%= if path = storybook_css_path(@conn) do %>
-      <link phx-track-static rel="stylesheet" href={application_static_path(path)}/>
+      <link nonce={csp_nonce(@conn, :style)} phx-track-static rel="stylesheet" href={application_static_path(path)}/>
     <% end %>
   </head>
   

--- a/lib/phoenix_storybook/views/layout_view.ex
+++ b/lib/phoenix_storybook/views/layout_view.ex
@@ -172,4 +172,15 @@ defmodule PhoenixStorybook.LayoutView do
 
     ["lsb-sandbox", container_class, backend_module(conn_or_socket).config(:sandbox_class)]
   end
+
+  # for conn
+  def csp_nonce(%Plug.Conn{} = conn, type) when type in [:script, :style, :img] do
+    csp_nonce_assign_key = conn.private.csp_nonce_assign_key[type]
+    conn.assigns[csp_nonce_assign_key]
+  end
+
+  # for liveview
+  def csp_nonce(csp_nonces, type) when type in [:script, :style, :img] do
+    csp_nonces[type]
+  end
 end


### PR DESCRIPTION
Related to https://github.com/phenixdigital/phoenix_storybook/issues/149

To test this, add `csp_nonce_assign_key` to the `live_storybook` options, and add the function `put_csp/2` to the router of `phoenix_storybook_sample`. 

```elixir
  scope "/", PhoenixStorybookSample do
    pipe_through(:browser)
    get "/", RedirectController, :redirect_to_storybook
    live("/page", PageLive, :index)

    live_storybook("/storybook",
      backend_module: Storybook,
      csp_nonce_assign_key: %{
        img: :img_src_nonce,
        style: :style_src_nonce,
        script: :script_src_nonce
      }
    )
  end

  def put_csp(conn, _params) do
    [img_nonce, style_nonce, script_nonce] =
      for _i <- 1..3, do: 16 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)

    conn
    |> assign(:img_src_nonce, img_nonce)
    |> assign(:style_src_nonce, style_nonce)
    |> assign(:script_src_nonce, script_nonce)
    |> put_resp_header(
      "content-security-policy",
      "default-src; script-src 'nonce-#{script_nonce}'; style-src 'nonce-#{style_nonce}'; img-src 'nonce-#{img_nonce}' ; font-src 'self' https://rsms.me https://*.fontawesome.com ; connect-src 'self' https://*.fontawesome.com ; frame-src 'self' ; manifest-src 'self' ;"
    )
  end
```

I also had to comment out the font awesome lines in `Storybook`, still in the same `phoenix_storybook_sample` repo.

```elixir
defmodule Storybook do
  use PhoenixStorybook,
    otp_app: :phoenix_storybook_sample,
    # ...
    # font_awesome_plan: :pro,
    # font_awesome_kit_id: "7a72374eed",
    compilation_mode: :eager
end
```

I would really appreciate any help by someone who is better than me on the frontend side of this 😅 