### PR TITLE
Use default `config_path` to allow compiling from hex.pm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,6 @@ defmodule PhoenixStorybook.MixProject do
       version: @version,
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
-      config_path: "./config/config.exs",
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "phoenix_storybook",
       description: "A pluggable storybook for your Phoenix components.",


### PR DESCRIPTION
`config/config.exs` is the [default](https://hexdocs.pm/mix/1.12/Mix.Project.html#module-configuration).

Publishing the package with it specified but the path missing causes compilation (and potentially) other issues when pulling from hex.pm. 

closes: #335