### PR TITLE
Color mode toggle

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,6 +13,28 @@ if (window.storybook === undefined) {
   window.storybook = {};
 }
 
+const colorModeHook = {
+  mounted() {
+    if (!localStorage.psb_theme) return
+    const colorMode = localStorage.getItem("psb_theme")
+    this.pushEvent("psb:color-mode", { "color-mode": colorMode })
+  },
+};
+
+function toggleColorMode(){
+  const htmlClass = document.documentElement.classList.contains('psb-dark')
+  if(localStorage.psb_theme == 'dark' && !htmlClass) document.documentElement.classList.add('psb-dark')
+  else if(localStorage.psb_theme == 'light' && htmlClass) document.documentElement.classList.remove('psb-dark')
+}
+
+window.addEventListener("psb:toggle-darkmode", () => {
+  if(localStorage.psb_theme == 'light') localStorage.psb_theme = 'dark';
+  else localStorage.psb_theme = 'light';
+  toggleColorMode();
+})
+
+toggleColorMode();
+
 let socketPath =
   document.querySelector("html").getAttribute("phx-socket") || "/live";
 
@@ -21,7 +43,7 @@ let csrfToken = document
   ?.getAttribute("content");
 
 let liveSocket = new LiveSocket(socketPath, Socket, {
-  hooks: { ...window.storybook.Hooks, StoryHook, SearchHook, SidebarHook },
+  hooks: { ...window.storybook.Hooks, StoryHook, SearchHook, SidebarHook, colorModeHook },
   uploaders: window.storybook.Uploaders,
   params: (liveViewName) => {
     return {

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -31,4 +31,5 @@ module.exports = {
   },
   important: ".psb",
   prefix: "psb-",
+  darkMode: "class"
 };

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -32,7 +32,8 @@ defmodule PhoenixStorybook.StoryLive do
        playground_preview_pid: nil,
        playground_topic: playground_topic,
        fa_plan: backend_module.config(:font_awesome_plan, :free),
-       connect_params: connect_params
+       connect_params: connect_params,
+       color_mode: "light"
      )}
   end
 
@@ -572,6 +573,14 @@ defmodule PhoenixStorybook.StoryLive do
     id |> to_string() |> String.replace("_", "-")
   end
 
+  defp assign_color_mode(socket, %{"mode" => "dark"}) do
+    socket |> assign(color_mode: "light")
+  end
+
+  defp assign_color_mode(socket, %{"mode" => "light"}) do
+    socket |> assign(color_mode: "dark")
+  end
+
   def handle_event("set-theme", %{"theme" => theme}, socket) do
     PubSub.broadcast!(
       PhoenixStorybook.PubSub,
@@ -585,6 +594,15 @@ defmodule PhoenixStorybook.StoryLive do
      socket
      |> assign(:theme, theme)
      |> patch_to(socket.assigns.root_path, socket.assigns.story_path, %{theme: theme})}
+  end
+
+  def handle_event("set-color-mode", params, socket) do
+    JS.dispatch("psb:toggle-darkmode")
+    {:noreply, socket |> assign_color_mode(params)}
+  end
+
+  def handle_event("psb:color-mode", %{"color-mode" => mode}, socket) do
+    {:noreply, assign(socket, color_mode: mode)}
   end
 
   def handle_event("set-tab", %{"tab" => tab}, socket) do

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -8,8 +8,12 @@
       </.link>
     </div>
 
-    <%= if themes = themes(@socket) do %>
-      <div class="psb psb-absolute psb-top-4 psb-right-14 lg:psb-right-5 psb-inline-block">
+    <div id="buttons-container" class="psb psb-absolute psb-top-4 psb-right-14 lg:psb-right-5 psb-flex psb-gap-2" phx-hook="colorModeHook">
+      <button type="button" class="psb psb-h-7 psb-w-7 psb-bg-gray-100 dark:psb-bg-gray-900 psb-rounded-full psb-flex psb-flex-row psb-justify-center psb-items-center psb-text-gray-400 hover:psb-text-indigo-600 dark:psb-text-yellow-500 focus:psb-outline-none focus:psb-ring-2 focus:psb-ring-offset-2 focus:psb-ring-offset-gray-100 focus:psb-ring-indigo-500" phx-click={JS.push("set-color-mode", value: %{"mode" => @color_mode }) |> JS.dispatch("psb:toggle-darkmode")}>
+        <.fa_icon style={:regular} name="lightbulb" plan={@fa_plan}/>
+      </button>
+      <%= if themes = themes(@socket) do %>
+      <div class="psb psb-inline-block">
         <button type="button" class="psb psb-h-7 psb-w-7 psb-bg-gray-100 psb-rounded-full psb-flex psb-flex-row psb-justify-center psb-items-center psb-text-gray-400 hover:psb-text-indigo-600 focus:psb-outline-none focus:psb-ring-2 focus:psb-ring-offset-2 focus:psb-ring-offset-gray-100 focus:psb-ring-indigo-500" phx-click={JS.show(to: "#psb-theme-dropdown", transition: show_dropdown_transition())}>
           <.fa_icon style={:regular} name="palette" class={current_theme_dropdown_class(@socket, assigns)} plan={@fa_plan}/>
         </button>
@@ -35,7 +39,8 @@
           </div>
         </div>
       </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 
   <div class="psb lg:psb-hidden psb-absolute psb-top-4 psb-right-5 psb-inline-block ">


### PR DESCRIPTION
Closes #283

With using tailwind to add darkmode, there's quite a bit of work still left to do, adding "psb:dark: ... " in lots of places. I had started this work prior to the "lsb -> psb" change.
Anyhow, there's a bit of stylistic decision-making involved, so might be for the better.

* Added a button to toggle color mode next to the themes dropdown, which adds or removes the class "dark" to the html tag, enabling tailwind-powered color mode switch.
* Saving selected color mode to localstorage to persist choice.