### PR TITLE
No-op events unknown on StoryLive

### DIFF
--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -666,6 +666,10 @@ defmodule PhoenixStorybook.StoryLive do
     {:noreply, assign(socket, :variation_extra_assigns, variation_extra_assigns)}
   end
 
+  def handle_event(_, _, socket) do
+    {:noreply, socket}
+  end
+
   def handle_info({:playground_preview_pid, pid}, socket) do
     Process.monitor(pid)
 

--- a/test/fixtures/components/event_component.ex
+++ b/test/fixtures/components/event_component.ex
@@ -8,7 +8,7 @@ defmodule EventComponent do
       |> assign_new(:label, fn -> "" end)
 
     ~H"""
-    <button phx-click="greet">component: <%= @label %><%= if @theme do %> <%= @theme %><% end %></button>
+    <button id="event-component" phx-click="greet">component: <%= @label %><%= if @theme do %> <%= @theme %><% end %></button>
     """
   end
 end

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -84,6 +84,14 @@ defmodule PhoenixStorybook.StoryLiveTest do
       assert html =~ "Component first doc paragraph."
     end
 
+    test "no-ops events from an event component", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/storybook/event/event_component")
+      assert html =~ "Hello variation"
+      view |> element("#event-component") |> render_click()
+      # This will raise if there's no default handle_event clause
+      assert true
+    end
+
     test "renders component story and navigate to source tab", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component")
 


### PR DESCRIPTION
Since StoryLive is responsible for rendering components, any events from the components are sent to StoryLive. If handle_event is called for an unknown event, a FunctionClauseError will be raised, crashing the LiveView. This can be particularly problematic for any components that trigger an event on render.

This commit adds a catch all clause to handle_event/3