### PR TITLE
Explicitly define step for range with negative index to get rid of warning

### DIFF
--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -231,7 +231,7 @@ defmodule PhoenixStorybook.StoryLive do
         <.fa_icon name="caret-down" style={:thin} plan={@fa_plan} class="psb-mr-1" /> Read less
       </a>
       <div id="doc-next" class="psb-hidden psb-space-y-4 ">
-        <%= for paragraph <- Enum.slice(@doc, 1..-1) do %>
+        <%= for paragraph <- Enum.slice(@doc, 1..-1//1) do %>
           <div class="psb psb-text-sm md:psb-text-base psb-leading-7 psb-text-slate-700">
             <%= raw(paragraph) %>
           </div>


### PR DESCRIPTION
Explicitly define the step for range with a negative index to get rid of the `negative steps are not supported in Enum.slice/2, pass 1..-1//1 instead` warning.