### PR TITLE
Fix Elixir 1.17 warnings

### DIFF
--- a/lib/phoenix_storybook/helpers/validation_helpers.ex
+++ b/lib/phoenix_storybook/helpers/validation_helpers.ex
@@ -79,7 +79,7 @@ defmodule PhoenixStorybook.ValidationHelpers do
   def match_attr_type?(term, :float) when is_float(term), do: true
   def match_attr_type?(term, :boolean) when is_boolean(term), do: true
   def match_attr_type?(term, :list) when is_list(term), do: true
-  def match_attr_type?(_min.._max, :range), do: true
+  def match_attr_type?(_min.._max//_, :range), do: true
   def match_attr_type?(term, :global) when is_map(term), do: true
   def match_attr_type?(term, :map) when is_map(term), do: true
   def match_attr_type?(term, :function) when is_function(term), do: true

--- a/lib/phoenix_storybook/live/story/playground.ex
+++ b/lib/phoenix_storybook/live/story/playground.ex
@@ -754,7 +754,7 @@ defmodule PhoenixStorybook.Story.Playground do
     """
   end
 
-  defp attr_input(assigns = %{type: :integer, values: min..max}) do
+  defp attr_input(assigns = %{type: :integer, values: min..max//_}) do
     assigns = assigns |> assign(:min, min) |> assign(:max, max)
 
     ~H"""

--- a/lib/phoenix_storybook/stories/story_validator.ex
+++ b/lib/phoenix_storybook/stories/story_validator.ex
@@ -145,15 +145,15 @@ defmodule PhoenixStorybook.Stories.StoryValidator do
 
   defp validate_component_aliases!(file_path, story) do
     msg = "story aliases must be a list of atoms"
-    validate_type!(file_path, story.aliases, :list, msg)
+    validate_type!(file_path, story.aliases(), :list, msg)
 
-    for alias_item <- story.aliases || [],
+    for alias_item <- story.aliases() || [],
         do: validate_type!(file_path, alias_item, :atom, msg)
   end
 
   defp validate_component_imports!(file_path, story) do
     msg = "story imports must be a list of {atom, [{atom, integer}]}"
-    validate_type!(file_path, story.aliases, :list, msg)
+    validate_type!(file_path, story.aliases(), :list, msg)
 
     for import_item <- story.imports || [] do
       validate_type!(file_path, import_item, {:tuple, 2}, msg)

--- a/lib/phoenix_storybook/stories/story_validator.ex
+++ b/lib/phoenix_storybook/stories/story_validator.ex
@@ -155,7 +155,7 @@ defmodule PhoenixStorybook.Stories.StoryValidator do
     msg = "story imports must be a list of {atom, [{atom, integer}]}"
     validate_type!(file_path, story.aliases(), :list, msg)
 
-    for import_item <- story.imports || [] do
+    for import_item <- story.imports() || [] do
       validate_type!(file_path, import_item, {:tuple, 2}, msg)
       {mod, functions} = import_item
       validate_type!(file_path, mod, :atom, msg)


### PR DESCRIPTION
Tried to plug in `elixir 1.17.0-rc.0-otp-27` and had some compilation warnings. Here are some of the fixes.