### PR TITLE
Add :compilation_debug config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ defmodule MyAppWeb.Storybook do
     #   - When eager: all .story.exs & .index.exs files are compiled upfront.
     #   - When lazy: only .index.exs files are compiled upfront and .story.exs are compile when the
     #     matching story is loaded in UI.
-    compilation_mode: :eager
+    compilation_mode: :eager,
+    
+    # If you want to see debugging logs for storybooks compilation, set this to `true`. Default: `false`
+    compilation_debug: true
   ]
 ```
 

--- a/lib/phoenix_storybook.ex
+++ b/lib/phoenix_storybook.ex
@@ -115,7 +115,7 @@ defmodule PhoenixStorybook do
 
             story =
               story_path
-              |> ExsCompiler.compile_exs!(content_path)
+              |> ExsCompiler.compile_exs!(content_path, opts)
               |> StoryValidator.validate!()
 
             quote do
@@ -194,9 +194,7 @@ defmodule PhoenixStorybook do
   end
 
   defp content_tree(opts) do
-    content_path = Keyword.get(opts, :content_path)
-    folders_config = Keyword.get(opts, :folders, [])
-    Entries.content_tree(content_path, folders_config)
+    Entries.content_tree(opts)
   end
 
   defp compilation_mode(opts) do

--- a/test/mix/tasks/phx.gen.storybook_test.exs
+++ b/test/mix/tasks/phx.gen.storybook_test.exs
@@ -130,7 +130,7 @@ defmodule Mix.Tasks.Phx.Gen.StorybookTest do
       Storybook.run([])
 
       story_file = "storybook/core_components/button.story.exs"
-      story = ExsCompiler.compile_exs!(story_file)
+      story = ExsCompiler.compile_exs!(story_file, "./")
       assert story.storybook_type() == :component
       assert story.function() == &PhoenixStorybookWeb.CoreComponents.button/1
 

--- a/test/phoenix_storybook/exs_compiler_test.exs
+++ b/test/phoenix_storybook/exs_compiler_test.exs
@@ -28,14 +28,37 @@ defmodule PhoenixStorybook.ExsCompilerTest do
   end
 
   describe "compile_exs!/2" do
-    test "can load a valid exs", %{exs: exs, path: path} do
-      assert ExsCompiler.compile_exs!(exs, path) == PhoenixStorybook.Script
+    test "can load a valid exs, logs nothing by default", %{exs: exs, path: path} do
+      log =
+        capture_log(fn ->
+          assert ExsCompiler.compile_exs!(exs, path) == PhoenixStorybook.Script
+        end)
+
+      refute log =~ "compiling"
     end
 
     test "it raises with bad script", %{bad_exs: exs, path: path} do
       assert_raise TokenMissingError, fn ->
         ExsCompiler.compile_exs!(exs, path)
       end
+    end
+
+    test "it logs when compilation_debug is set to true", %{
+      exs: exs,
+      path: path
+    } do
+      previous_logger_level = Logger.level()
+      Logger.configure(level: :debug)
+
+      log =
+        capture_log(fn ->
+          assert ExsCompiler.compile_exs!(exs, path, compilation_debug: true) ==
+                   PhoenixStorybook.Script
+        end)
+
+      Logger.configure(level: previous_logger_level)
+
+      assert log =~ "compiling storybook file: #{exs}"
     end
   end
 end


### PR DESCRIPTION
Closes #478

I had to make the `opts` available a bit deeper in the code, to read the `:compilation_debug` config option, but otherwise it seems to be a straightforward fix.

I am happy to adjust it based on your review or feel free to do it by yourself.

Thanks. :-)