### PR TITLE
Component stories can now render only function code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## v0.7.3 (not released)
 
+- **feature**: [render only component function's source code for component stories](https://github.com/phenixdigital/phoenix_storybook/issues/529)
 - **bugfix**: fixed broken playground for stories using templating features
 
 ## v0.7.2 (2024-12-06)

--- a/guides/components.md
+++ b/guides/components.md
@@ -346,3 +346,21 @@ defmodule Storybook.Components.Breadcrumb do
   # ...
 end
 ```
+
+## Source code
+
+Storybook renders the source code for any of your components.
+
+By default, it displays the complete module source code. For function components, you can choose to
+render only the function's source code by adding a `render_only_function_source/1` function to your
+story.
+
+```elixir
+defmodule Storybook.Components.Breadcrumb do
+  use PhoenixStorybook.Story, :component
+
+  def layout, do: :one_column
+
+  # ...
+end
+```

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -501,7 +501,7 @@ defmodule PhoenixStorybook.StoryLive do
   defp render_content(type, assigns = %{tab: :source})
        when type in [:component, :live_component] do
     ~H"""
-    <div class="psb psb-flex-1 psb-flex psb-flex-col psb-overflow-auto psb-max-h-full ">
+    <div class="psb psb-flex-1 psb-flex psb-flex-col psb-overflow-auto psb-max-h-full">
       <%= @story |> CodeRenderer.render_component_source() |> to_raw_html() %>
     </div>
     """

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -501,7 +501,7 @@ defmodule PhoenixStorybook.StoryLive do
   defp render_content(type, assigns = %{tab: :source})
        when type in [:component, :live_component] do
     ~H"""
-    <div class="psb psb-flex-1 psb-flex psb-flex-col psb-overflow-auto psb-max-h-full">
+    <div class="psb psb-flex-1 psb-flex psb-flex-col psb-overflow-auto psb-max-h-full ">
       <%= @story |> CodeRenderer.render_component_source() |> to_raw_html() %>
     </div>
     """

--- a/lib/phoenix_storybook/rendering/code_renderer.ex
+++ b/lib/phoenix_storybook/rendering/code_renderer.ex
@@ -102,7 +102,7 @@ defmodule PhoenixStorybook.Rendering.CodeRenderer do
   Returns a rendered HEEx template.
   """
   def render_component_source(story) do
-    if story.storybook_type() == :component and story.render_only_function_source() do
+    if story.storybook_type() == :component && story.render_only_function_source() do
       render_source(story.__component_source__())
     else
       render_source(story.__module_source__())
@@ -116,7 +116,7 @@ defmodule PhoenixStorybook.Rendering.CodeRenderer do
     assigns = assign(assigns, source: source)
 
     ~H"""
-    <pre class={[pre_class(), "dark:psb-border-slate-600 "]}>
+    <pre class={[pre_class(), "dark:psb-border-slate-600"]}>
     <%= format_elixir(@source) %>
     </pre>
     """

--- a/lib/phoenix_storybook/rendering/code_renderer.ex
+++ b/lib/phoenix_storybook/rendering/code_renderer.ex
@@ -102,7 +102,11 @@ defmodule PhoenixStorybook.Rendering.CodeRenderer do
   Returns a rendered HEEx template.
   """
   def render_component_source(story) do
-    render_source(story.__component_source__())
+    if story.storybook_type() == :component and story.render_only_function_source() do
+      render_source(story.__component_source__())
+    else
+      render_source(story.__module_source__())
+    end
   end
 
   def render_source(source, assigns \\ %{__changed__: %{}})
@@ -112,7 +116,7 @@ defmodule PhoenixStorybook.Rendering.CodeRenderer do
     assigns = assign(assigns, source: source)
 
     ~H"""
-    <pre class={pre_class()}>
+    <pre class={[pre_class(), "dark:psb-border-slate-600 "]}>
     <%= format_elixir(@source) %>
     </pre>
     """

--- a/lib/phoenix_storybook/stories/story.ex
+++ b/lib/phoenix_storybook/stories/story.ex
@@ -27,7 +27,7 @@ defmodule PhoenixStorybook.Story do
     # required
     def function, do: &MyAppWeb.MyComponent.my_component/1
 
-    # defaults to false (source tab will render the full module source code)
+    # when true, the source tab will render only function's source code (defaults to false)
     def render_only_function_source, do: true
 
     def attributes, do: []

--- a/lib/phoenix_storybook/stories/story.ex
+++ b/lib/phoenix_storybook/stories/story.ex
@@ -27,6 +27,9 @@ defmodule PhoenixStorybook.Story do
     # required
     def function, do: &MyAppWeb.MyComponent.my_component/1
 
+    # defaults to false (source tab will render the full module source code)
+    def render_only_function_source, do: true
+
     def attributes, do: []
     def slots, do: []
     def variations, do: []
@@ -140,6 +143,7 @@ defmodule PhoenixStorybook.Story do
     @callback variations() :: [Variation.t() | VariationGroup.t()]
     @callback template() :: String.t()
     @callback layout() :: atom()
+    @callback render_only_function_source() :: atom()
   end
 
   defmodule LiveComponentBehaviour do
@@ -154,6 +158,7 @@ defmodule PhoenixStorybook.Story do
     @callback variations() :: [Variation.t() | VariationGroup.t()]
     @callback template() :: String.t()
     @callback layout() :: atom()
+    @callback render_only_function_source() :: atom()
   end
 
   defmodule PageBehaviour do
@@ -216,6 +221,9 @@ defmodule PhoenixStorybook.Story do
       @impl unquote(component_behaviour(live?))
       def layout, do: :two_columns
 
+      @impl unquote(component_behaviour(live?))
+      def render_only_function_source, do: false
+
       if unquote(live?) do
         def merged_attributes, do: Attr.merge_attributes(component(), attributes())
         def merged_slots, do: Slot.merge_slots(component(), slots())
@@ -231,7 +239,8 @@ defmodule PhoenixStorybook.Story do
                      slots: 0,
                      variations: 0,
                      template: 0,
-                     layout: 0
+                     layout: 0,
+                     render_only_function_source: 0
     end
   end
 

--- a/lib/phoenix_storybook/stories/story_source.ex
+++ b/lib/phoenix_storybook/stories/story_source.ex
@@ -46,8 +46,6 @@ defmodule PhoenixStorybook.Stories.StorySource do
     end
   rescue
     _ -> component_source_fail(env)
-  catch
-    _ -> component_source_fail(env)
   end
 
   defp component_source_fail(env) do
@@ -67,8 +65,6 @@ defmodule PhoenixStorybook.Stories.StorySource do
         []
     end
   rescue
-    _ -> extra_sources_fail(env)
-  catch
     _ -> extra_sources_fail(env)
   end
 
@@ -130,8 +126,6 @@ defmodule PhoenixStorybook.Stories.StorySource do
     end
   rescue
     _ -> component_source_fail(env)
-  catch
-    _ -> component_source_fail(env)
   end
 
   defp read_file_source(nil), do: nil
@@ -181,7 +175,6 @@ defmodule PhoenixStorybook.Stories.StorySource do
     |> then(fn
       {_, start, nil} -> [start - 1, -3]
       {_, start, stop} -> [start - 1, stop - 2]
-      _ -> nil
     end)
   end
 

--- a/priv/templates/phx.gen.storybook/core_components/button.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/button.story.exs.eex
@@ -2,6 +2,7 @@ defmodule Storybook.CoreComponents.Button do
   use PhoenixStorybook.Story, :component
 
   def function, do: &<%= schema.core_components_module_name %>.button/1
+  def render_only_function_source, do: true
 
   def variations do
     [

--- a/priv/templates/phx.gen.storybook/core_components/flash.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/flash.story.exs.eex
@@ -4,6 +4,7 @@ defmodule Storybook.CoreComponents.Flash do
 
   def function, do: &CoreComponents.flash/1
   def imports, do: [{CoreComponents, [button: 1, show: 1]}]
+  def render_only_function_source, do: true
 
   def template do
     """

--- a/priv/templates/phx.gen.storybook/core_components/header.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/header.story.exs.eex
@@ -4,6 +4,7 @@ defmodule Storybook.CoreComponents.Header do
 
   def function, do: &CoreComponents.header/1
   def imports, do: [{CoreComponents, button: 1}]
+  def render_only_function_source, do: true
 
   def variations do
     [

--- a/priv/templates/phx.gen.storybook/core_components/input.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/input.story.exs.eex
@@ -4,6 +4,7 @@ defmodule Storybook.CoreComponents.Input do
 
   def function, do: &CoreComponents.input/1
   def imports, do: [{CoreComponents, [simple_form: 1]}]
+  def render_only_function_source, do: true
 
   def template do
     """

--- a/priv/templates/phx.gen.storybook/core_components/list.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/list.story.exs.eex
@@ -2,6 +2,7 @@ defmodule Storybook.CoreComponents.List do
   use PhoenixStorybook.Story, :component
 
   def function, do: &<%= schema.core_components_module_name %>.list/1
+  def render_only_function_source, do: true
 
   def variations do
     [

--- a/priv/templates/phx.gen.storybook/core_components/modal.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/modal.story.exs.eex
@@ -4,6 +4,7 @@ defmodule Storybook.CoreComponents.Modal do
 
   def function, do: &CoreComponents.modal/1
   def imports, do: [{CoreComponents, [button: 1, hide_modal: 1, show_modal: 1]}]
+  def render_only_function_source, do: true
 
   def template do
     """

--- a/priv/templates/phx.gen.storybook/core_components/table.story.exs.eex
+++ b/priv/templates/phx.gen.storybook/core_components/table.story.exs.eex
@@ -4,6 +4,7 @@ defmodule Storybook.CoreComponents.Table do
 
   def function, do: &CoreComponents.table/1
   def aliases, do: [Storybook.CoreComponents.Table.User]
+  def render_only_function_source, do: true
 
   def variations do
     [

--- a/test/fixtures/components/component.ex
+++ b/test/fixtures/components/component.ex
@@ -16,4 +16,10 @@ defmodule Component do
 
     ~H"<span data-index={@index}>component: <%= @label %><%= if @theme do %> <%= @theme %><% end %></span>"
   end
+
+  @doc """
+  Should not be extracted in Component.component/1 source code.
+  """
+  def unrelated_function, do: nil
+
 end

--- a/test/fixtures/storybook_content/tree/a_folder/component.story.exs
+++ b/test/fixtures/storybook_content/tree/a_folder/component.story.exs
@@ -1,6 +1,7 @@
 defmodule TreeStorybook.AFolder.Component do
   use PhoenixStorybook.Story, :component
   def function, do: &Component.component/1
+  def render_only_function_source, do: true
   def container, do: {:div, class: "block", "data-foo": "bar"}
 
   def variations do

--- a/test/fixtures/stubs/component_stub.ex
+++ b/test/fixtures/stubs/component_stub.ex
@@ -36,4 +36,8 @@ defmodule PhoenixStorybook.ComponentStub do
 
   @impl ComponentBehaviour
   def layout, do: :two_columns
+
+  @impl ComponentBehaviour
+  def render_only_function_source, do: false
+
 end

--- a/test/fixtures/stubs/live_component_stub.ex
+++ b/test/fixtures/stubs/live_component_stub.ex
@@ -36,4 +36,7 @@ defmodule PhoenixStorybook.LiveComponentStub do
 
   @impl LiveComponentBehaviour
   def layout, do: :two_columns
+
+  @impl LiveComponentBehaviour
+  def render_only_function_source, do: false
 end

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -92,7 +92,9 @@ defmodule PhoenixStorybook.StoryLiveTest do
       assert true
     end
 
-    test "renders component story and navigate to source tab", %{conn: conn} do
+    test "renders component story, navigate to source tab and see full module source", %{
+      conn: conn
+    } do
       {:ok, view, _html} = live(conn, "/storybook/component")
 
       html = view |> element("a", "Source") |> render_click()
@@ -103,6 +105,25 @@ defmodule PhoenixStorybook.StoryLiveTest do
       )
 
       assert html =~ "defmodule"
+      assert html =~ "component"
+      assert html =~ "unrelated_function"
+    end
+
+    test "renders component story, navigate to source tab and see function only source", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, "/storybook/a_folder/component")
+
+      html = view |> element("a", "Source") |> render_click()
+
+      assert_patched(
+        view,
+        ~p"/storybook/a_folder/component?#{[tab: :source, theme: :default, variation_id: :group]}"
+      )
+
+      assert html =~ "defmodule"
+      assert html =~ "component"
+      refute html =~ "unrelated_function"
     end
 
     test "renders component, change theme and navigate", %{conn: conn} do

--- a/test/phoenix_storybook/stories/story_source_test.exs
+++ b/test/phoenix_storybook/stories/story_source_test.exs
@@ -6,7 +6,20 @@ defmodule PhoenixStorybook.Stories.StorySourceTest do
   describe "__component_source__/0" do
     test "it returns component source" do
       {:ok, story} = TreeStorybook.load_story("/component")
-      assert story.__component_source__() =~ ~s|defmodule Component do|
+      source = story.__component_source__()
+      assert source =~ ~s|defmodule Component do|
+      assert source =~ ~s|def component(assigns) do|
+      refute source =~ ~s|def unrelated_function|
+      refute source =~ ~s|use Phoenix.Component|
+    end
+
+    test "it returns module source" do
+      {:ok, story} = TreeStorybook.load_story("/component")
+      source = story.__module_source__()
+      assert source =~ ~s|defmodule Component do|
+      assert source =~ ~s|def component(assigns) do|
+      assert source =~ ~s|def unrelated_function|
+      assert source =~ ~s|use Phoenix.Component|
     end
 
     @tag :capture_log


### PR DESCRIPTION
- **story_source component_source only returns function source code for function components**
- **storybook renders function source code if opted in story**
- **generated core_component stories render only function source**
- **test warnings**
- **doc**
