### PR TITLE
Highlight code blocks in components docs

### DIFF
--- a/lib/phoenix_storybook/stories/doc.ex
+++ b/lib/phoenix_storybook/stories/doc.ex
@@ -3,6 +3,8 @@ defmodule PhoenixStorybook.Stories.Doc do
   Functions to fetch component documentation and render it at HTML.
   """
 
+  alias Phoenix.HTML.Safe, as: HTMLSafe
+  alias PhoenixStorybook.Rendering.CodeRenderer
   alias PhoenixStorybook.Stories.Doc
 
   require Logger
@@ -95,6 +97,37 @@ defmodule PhoenixStorybook.Stories.Doc do
   end
 
   defp format(doc) do
-    doc |> Earmark.as_html() |> elem(1)
+    doc |> Earmark.as_html!() |> highlight_code_blocks()
   end
+
+  defp highlight_code_blocks(html) do
+    regex = ~r/<pre><code(?:\s+class="(\w*)")?>([^<]*)<\/code><\/pre>/
+    Regex.replace(regex, html, &highlight_code_block/3)
+  end
+
+  defp highlight_code_block(_full_match, lang, escaped_code) do
+    code = escaped_code |> unescape_html() |> IO.iodata_to_binary()
+
+    lang =
+      case lang do
+        "elixir" -> :elixir
+        "heex" -> :heex
+        "" -> code |> String.trim_leading() |> guess_lang()
+      end
+
+    CodeRenderer.render_code_block(code, lang, trim: false)
+    |> HTMLSafe.to_iodata()
+  end
+
+  defp guess_lang("<" <> _), do: :heex
+  defp guess_lang(_code), do: :elixir
+
+  entities = [{"&amp;", ?&}, {"&lt;", ?<}, {"&gt;", ?>}, {"&quot;", ?"}, {"&#39;", ?'}]
+
+  for {encoded, decoded} <- entities do
+    defp unescape_html(unquote(encoded) <> rest), do: [unquote(decoded) | unescape_html(rest)]
+  end
+
+  defp unescape_html(<<c, rest::binary>>), do: [c | unescape_html(rest)]
+  defp unescape_html(<<>>), do: []
 end

--- a/test/fixtures/components/component.ex
+++ b/test/fixtures/components/component.ex
@@ -6,6 +6,28 @@ defmodule Component do
   Still first paragraph.
 
   Second paragraph.
+
+  ## Examples
+
+      <.component label="hello" />
+
+  and
+
+      iex> Component.component(%{label: "hello"})
+      %Phoenix.LiveView.Rendered{}
+
+  and
+
+  ```heex
+  <.component theme={:cool} />
+  ```
+
+  and
+
+  ```elixir
+  iex> Component.component(%{theme: :boring})
+  %Phoenix.LiveView.Rendered{}
+  ```
   """
 
   attr :theme, :atom, default: nil

--- a/test/phoenix_storybook/live/playground_live_test.exs
+++ b/test/phoenix_storybook/live/playground_live_test.exs
@@ -33,7 +33,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
     test "renders playground code a simple component", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component?tab=playground")
       view |> element("a", "Code") |> render_click()
-      assert view |> element("pre") |> render() =~ "hello"
+      assert view |> element("#playground pre") |> render() =~ "hello"
     end
 
     test "playground code is updated as form is changed", %{conn: conn} do
@@ -44,7 +44,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
       |> form("#tree_storybook_component-playground-form", %{playground: %{label: "world"}})
       |> render_change()
 
-      assert view |> element("pre") |> render() =~ "world"
+      assert view |> element("#playground pre") |> render() =~ "world"
 
       view |> element("a", "Preview") |> render_click()
       assert view |> element("#playground-preview-live") |> render() =~ "component: world"
@@ -84,7 +84,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
       |> form("#tree_storybook_component-playground-form", %{playground: %{label: "world"}})
       |> render_change()
 
-      assert view |> element("pre") |> render() =~ "world"
+      assert view |> element("#playground pre") |> render() =~ "world"
     end
 
     test "playground rendered HTML is unavailable for live_components", %{conn: conn} do

--- a/test/phoenix_storybook/rendering/code_renderer_test.exs
+++ b/test/phoenix_storybook/rendering/code_renderer_test.exs
@@ -236,6 +236,53 @@ defmodule PhoenixStorybook.Rendering.CodeRendererTest do
     end
   end
 
+  describe "render_code_block/3" do
+    test "it renders Elixir code" do
+      code = """
+      def hello_world do
+        IO.puts(\"Hello, world!\")
+      end
+      """
+
+      source = CodeRenderer.render_code_block(code, :elixir) |> rendered_to_string()
+      assert source =~ ~r/<pre.*psb highlight.*\/pre>/s
+      assert source =~ ~s[<span class="kd">def</span>]
+    end
+
+    test "it renders HEEx code" do
+      code = """
+      <.button phx-click="go">Send!</.button>
+      """
+
+      source = CodeRenderer.render_code_block(code, :heex) |> rendered_to_string()
+      assert source =~ ~r/<pre.*psb highlight.*\/pre>/s
+      assert source =~ ~s[<span class="nf">.button</span>]
+    end
+
+    test "it does not highlight syntax when `format: false` is given" do
+      code = """
+      <.button phx-click="go">Send!</.button>
+      """
+
+      source = CodeRenderer.render_code_block(code, :heex, format: false) |> rendered_to_string()
+      assert source =~ ~r/<pre.*psb highlight.*\/pre>/s
+      assert source =~ ~s[<.button phx-click="go">Send!</.button>]
+    end
+
+    test "it does not trim whitespace when `trim: false` is given" do
+      code = """
+        <.button phx-click="go">Send!</.button>
+      """
+
+      source =
+        CodeRenderer.render_code_block(code, :heex, trim: false, format: false)
+        |> rendered_to_string()
+
+      assert source =~ ~r/<pre.*psb highlight.*\/pre>/s
+      assert source =~ ~s[  <.button phx-click="go">Send!</.button>]
+    end
+  end
+
   describe "render booleans with their shorthand notation" do
     test "when true, the attribute is rendered, shorthand", %{all_types_component: component} do
       code = render_variation_code(component, :toggle_true)

--- a/test/phoenix_storybook/stories/doc_test.exs
+++ b/test/phoenix_storybook/stories/doc_test.exs
@@ -8,10 +8,16 @@ defmodule PhoenixStorybook.Stories.DocTest do
 
   describe "fetch_doc_as_html/2" do
     test "it returns a function component documentation" do
-      assert "component.story.exs" |> compile_story() |> Doc.fetch_doc_as_html() == %Doc{
+      assert %Doc{
                header: "<p>\n  Component first doc paragraph.\nStill first paragraph.</p>\n",
-               body: "<p>\nSecond paragraph.</p>\n"
-             }
+               body: "<p>\nSecond paragraph.</p>\n<h2>\nExamples</h2>" <> examples
+             } =
+               "component.story.exs" |> compile_story() |> Doc.fetch_doc_as_html()
+
+      assert examples =~ ~s[<span class="nf">.component</span>]
+      assert examples =~ ~s[<span class="nc">Component</span>]
+      assert examples =~ ~s[<span class="ss">:cool</span>]
+      assert examples =~ ~s[<span class="ss">:boring</span>]
     end
 
     test "it returns a live component documentation" do


### PR DESCRIPTION
Hi @cblavier!

Finally I got some time work on Phoenix Storybook. 🙁 With this PR, I am building on your great work in #525 and fixing the only leftover from #514 – syntax highlighting for code blocks in the docs.

The code for highlighting was heavily inspired by
https://github.com/dashbitco/nimble_publisher/blob/140066e4c7b39f2c93bae662d3606fca1c1dce4d/lib/nimble_publisher/highlighter.ex

It works for both HEEx and Elixir code. When the language is not explicitly mentioned, HEEx is assumed if the code block starts with `<` (for an HTML tag), otherwise Elixir is used.

![Screenshot 2025-01-17 at 11 20 43](https://github.com/user-attachments/assets/f66f72d2-aad3-4e44-9f04-a371c39d11dd)
