### PR TITLE
Support ESM imports for scripts

### DIFF
--- a/guides/sandboxing.md
+++ b/guides/sandboxing.md
@@ -38,6 +38,8 @@ Then set the `js_path: "/assets/storybook.js"` option to the storybook within yo
 file. This is a remote path (not a local file-system path) which means this file should be served
 by your own application endpoint with the given path.
 
+If you are using ESM-style imports, you can set the `js_script_type: "module"`" option as well.
+
 You can also use this script to inject whatever content you want into document `HEAD`, such as
 external scripts.
 

--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -38,13 +38,15 @@
       <script
         nonce={csp_nonce(@conn, :script)}
         phx-track-static
-        type="text/javascript"
+        defer={storybook_js_type(@conn) == "module"}
+        type={storybook_js_type(@conn)}
         src={application_static_path(path)}
       >
       </script>
     <% end %>
     <script
       nonce={csp_nonce(@conn, :script)}
+      defer={storybook_js_type(@conn) == "module"}
       type="text/javascript"
       src={asset_path(@conn, "js/app.js")}
     >

--- a/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root_iframe.html.heex
@@ -8,7 +8,7 @@
       <script
         nonce={csp_nonce(@conn, :script)}
         phx-track-static
-        type="text/javascript"
+        type={storybook_js_type(@conn)}
         src={application_static_path(path)}
       >
       </script>

--- a/lib/phoenix_storybook/views/layout_view.ex
+++ b/lib/phoenix_storybook/views/layout_view.ex
@@ -62,6 +62,7 @@ defmodule PhoenixStorybook.LayoutView do
 
   def storybook_css_path(conn), do: storybook_setting(conn, :css_path)
   def storybook_js_path(conn), do: storybook_setting(conn, :js_path)
+  def storybook_js_type(conn), do: storybook_setting(conn, :js_script_type, "text/javascript")
 
   defp title(conn_or_socket), do: storybook_setting(conn_or_socket, :title, "Live Storybook")
 


### PR DESCRIPTION
We are using unbundled JavaScript without a build process, using ESM-style imports in the process. This requires the `script` tag to have `type="module"` added.

This PR adds a new configuration option, `js_script_type`, that defaults to `text/javascript` - which was the previous default. In our case, we can set it to `module` to support our scripts.
In addition, in Storybook's case, Storybook's own assets need to be loaded after, so I added the `defer` tag.
