### PR TITLE
UX Tweaks

### DIFF
--- a/lib/phoenix_storybook/live/search.ex
+++ b/lib/phoenix_storybook/live/search.ex
@@ -53,6 +53,8 @@ defmodule PhoenixStorybook.Search do
           phx-show={show_modal()}
           phx-hide={hide_modal()}
           phx-click-away={JS.dispatch("psb:close-search")}
+          phx-window-keydown={JS.exec("phx-click-away")}
+          phx-key="Escape"
           class="psb psb-opacity-0 psb-scale-90 psb-mx-auto psb-max-w-xl psb-mt-16 psb-transform psb-divide-y psb-divide-gray-100 dark:psb-divide-slate-600 psb-overflow-hidden psb-rounded-xl psb-bg-white dark:psb-bg-slate-800 psb-shadow-2xl psb-transition-all"
         >
           <.form

--- a/lib/phoenix_storybook/live/sidebar.ex
+++ b/lib/phoenix_storybook/live/sidebar.ex
@@ -168,7 +168,7 @@ defmodule PhoenixStorybook.Sidebar do
                 <% end %>
                 <.link
                   patch={if t = assigns[:theme], do: "#{story_path}?theme=#{t}", else: story_path}
-                  class="psb group-hover:psb-text-indigo-600 dark:group-hover:psb-text-sky-400"
+                  class="psb psb-block psb-w-full psb-py-2 lg:psb-py-1 group-hover:psb-text-indigo-600 dark:group-hover:psb-text-sky-400"
                 >
                   {name}
                 </.link>
@@ -183,7 +183,7 @@ defmodule PhoenixStorybook.Sidebar do
 
   defp story_class(current_path, story_path) do
     story_class =
-      "psb psb-flex psb-items-center -psb-ml-[12px] psb-block psb-border-l psb-py-2 lg:psb-py-1 psb-pl-4 hover:psb-border-indigo-600 hover:psb-text-indigo-600 hover:psb-border-l-1.5 psb-group"
+      "psb psb-flex psb-items-center -psb-ml-[12px] psb-block psb-border-l psb-pl-4 hover:psb-border-indigo-600 hover:psb-text-indigo-600 hover:psb-border-l-1.5 psb-group"
 
     if current_path == story_path do
       story_class <>


### PR DESCRIPTION
Hey Christian!

First off, thanks so much for taking care of the `nil` showing in stories thing and I'm so sorry I never got to it myself.

This is a little PR to provide two little UX tweaks that have been mildly annoying me.  Feel free to reject one (or both) and I can rebase.

The first simply let's you close out the search modal with escape.  You have to hit it twice since the text box has focus, but that is par for the course on most sites.

The second increased the "hitbox" of the sidebar story links.  It applies the padding to the anchor tags as opposed to the wrapping divs.  It also makes them full width blocks.  I would often misclick as the text would get hover state in places it wasn't clickable.

Thanks!


https://github.com/user-attachments/assets/227c8078-d7b5-4d55-b7b1-a450a0eb473c

