### PR TITLE
Add DaisyUI Component storybook on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ A few storybooks running in production:
 - [Doggo](https://woylie-doggo.fly.dev/)
 - [Tremorx](https://tremorx.fly.dev/)
 - [Bloom](https://bloom-ui.fly.dev/)
+- [DaisyUI Components](https://daisy-ui-components-site.fly.dev/storybook/welcome)
 
 ## Contributing
 


### PR DESCRIPTION
hey @cblavier,

I created the [DaisyUI Components ](https://github.com/phcurado/daisy_ui_components) library which uses storybook to display the components. Can I add this lib on the examples of phoenix_storybook's readme as well? 

Appreciated and I really like your library, it was very easy to add the components there.