### PR TITLE
Improve example source code stripping

### DIFF
--- a/lib/phoenix_storybook/helpers/example_helpers.ex
+++ b/lib/phoenix_storybook/helpers/example_helpers.ex
@@ -1,0 +1,39 @@
+defmodule PhoenixStorybook.Helpers.ExampleHelpers do
+  @moduledoc false
+
+  def strip_example_source(code) do
+    with {:ok, ast, comments} <-
+           Code.string_to_quoted_with_comments(code,
+             literal_encoder: &{:ok, {:__block__, &2, [&1]}},
+             token_metadata: true,
+             unescape: false
+           ),
+         {:defmodule, m1, [aliases, [{{:__block__, m2, [:do]}, {:__block__, m3, block}}]]} <- ast do
+      new_block =
+        block
+        # drop doc and extra_sources functions from the source code
+        |> Enum.reject(fn
+          {:def, _, [{:doc, _, _} | _]} -> true
+          {:def, _, [{:extra_sources, _, _} | _]} -> true
+          _ -> false
+        end)
+        # replace `use PhoenixStorybook.Story, :example` with `use Phoenix.LiveView`
+        |> Enum.map(fn
+          {:use, m4, [{:__aliases__, _, [:PhoenixStorybook, :Story]}, _example]} ->
+            {:use, m4, [{:__aliases__, [], [:Phoenix, :LiveView]}]}
+
+          other ->
+            other
+        end)
+
+      new_ast =
+        {:defmodule, m1, [aliases, [{{:__block__, m2, [:do]}, {:__block__, m3, new_block}}]]}
+
+      algebra = Code.quoted_to_algebra(new_ast, comments: comments)
+      doc = Inspect.Algebra.format(algebra, 98)
+      IO.iodata_to_binary(doc)
+    else
+      _ -> code
+    end
+  end
+end

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -6,6 +6,7 @@ defmodule PhoenixStorybook.StoryLive do
 
   alias PhoenixStorybook.Events.EventLog
   alias PhoenixStorybook.ExtraAssignsHelpers
+  alias PhoenixStorybook.Helpers.ExampleHelpers
   alias PhoenixStorybook.LayoutView
   alias PhoenixStorybook.Rendering.CodeRenderer
   alias PhoenixStorybook.Story.{ComponentDoc, Playground, PlaygroundPreviewLive, Variations}
@@ -415,7 +416,7 @@ defmodule PhoenixStorybook.StoryLive do
     ~H"""
     <div class="psb psb-flex-1 psb-flex psb-flex-col psb-overflow-auto psb-max-h-full">
       {@story.__source__()
-      |> remove_example_code()
+      |> ExampleHelpers.strip_example_source()
       |> CodeRenderer.render_source()
       |> to_raw_html()}
     </div>
@@ -436,17 +437,6 @@ defmodule PhoenixStorybook.StoryLive do
         </div>
         """
     end
-  end
-
-  # removing Storybook's specific not useful while reading example's source code.
-  defp remove_example_code(code) do
-    code
-    # removing specifc storybook use
-    |> String.replace(~r|use\s+PhoenixStorybook\.Story\s*,\s*:example|, "use Phoenix.LiveView")
-    # removing multiline doc and extra_sources definition
-    |> String.replace(~r/def\s+(doc|extra_sources)\s*,\s*do:((?!end).)*end\s*/s, "")
-    # removing inline doc and extra_sources definition
-    |> String.replace(~r/def\s+(doc|extra_sources)\s+do:((?!end|def).)*/s, "")
   end
 
   defp to_raw_html(heex) do

--- a/test/phoenix_storybook/helpers/example_helpers_test.exs
+++ b/test/phoenix_storybook/helpers/example_helpers_test.exs
@@ -1,0 +1,384 @@
+defmodule PhoenixStorybook.Helpers.ExampleHelpersTest do
+  use ExUnit.Case, async: true
+
+  import PhoenixStorybook.Helpers.ExampleHelpers
+
+  @base_expected """
+  defmodule Storybook.Examples.Example do
+    use Phoenix.LiveView
+
+    def render(assigns) do
+      ~H"Hello world!"
+    end
+  end\
+  """
+
+  describe "strip_example_source/1" do
+    test "module without doc and extra sources" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with doc and without extra sources" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc do
+          "This is some example."
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with multiline doc and without extra sources" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc do
+          \"\"\"
+          This is some example.
+
+          It prints *hello world*.
+          \"\"\"
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with inline doc and without extra sources" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc, do: "This is some example."
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with inline doc and extra sources" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc, do: "This is some example."
+
+        def extra_sources do
+          [
+            "./template.html.heex",
+            "./my_page_html.ex"
+          ]
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with extra sources and doc" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def extra_sources do
+          [
+            "./template.html.heex",
+            "./my_page_html.ex"
+          ]
+        end
+
+        def doc do
+          "This is some example."
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with extra sources and inline doc" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def extra_sources do
+          [
+            "./template.html.heex",
+            "./my_page_html.ex"
+          ]
+        end
+
+        def doc, do: "This is some example."
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with extra sources and without doc" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def extra_sources do
+          [
+            "./template.html.heex",
+            "./my_page_html.ex"
+          ]
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with inline extra sources and without doc" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def extra_sources, do:
+          [
+            "./template.html.heex",
+            "./my_page_html.ex"
+          ]
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert @base_expected == strip_example_source(source)
+    end
+
+    test "module with extra sources and inline doc mixed with other functions" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def mount(_params, _session, socket) do
+          {:ok, socket}
+        end
+
+        def extra_sources do
+          [
+            "./template.html.heex",
+            "./my_page_html.ex"
+          ]
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+
+        def doc, do: "This is some example."
+
+        def handle_info(_msg, socket) do
+          {:noreply, socket}
+        end
+      end\
+      """
+
+      expected = """
+      defmodule Storybook.Examples.Example do
+        use Phoenix.LiveView
+
+        def mount(_params, _session, socket) do
+          {:ok, socket}
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+
+        def handle_info(_msg, socket) do
+          {:noreply, socket}
+        end
+      end\
+      """
+
+      assert expected == strip_example_source(source)
+    end
+
+    test "module with invalid syntax is left intact" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc do
+          "This is some example."
+        end
+
+        # trailing )
+        def render(assigns)) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert source == strip_example_source(source)
+    end
+
+    test "source without a module is left intact" do
+      source = """
+      1 + 1\
+      """
+
+      assert source == strip_example_source(source)
+    end
+
+    test "source with multiple modules is left intact" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc do
+          "This is some example."
+        end
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end
+      defmodule Storybook.Examples.OtherModule do
+        def answer, do: 42
+      end\
+      """
+
+      assert source == strip_example_source(source)
+    end
+
+    test "comments are preserved" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc, do: "This is some example."
+
+        # comment above render
+        def render(assigns) do
+          # comment inside render
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      expected = """
+      defmodule Storybook.Examples.Example do
+        use Phoenix.LiveView
+
+        # comment above render
+        def render(assigns) do
+          # comment inside render
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert expected == strip_example_source(source)
+    end
+
+    test "inline functions are preserved" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc, do: "This is some example."
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+
+        def mount(_params, _session, socket), do: {:ok, socket}
+      end\
+      """
+
+      expected = """
+      defmodule Storybook.Examples.Example do
+        use Phoenix.LiveView
+
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+
+        def mount(_params, _session, socket), do: {:ok, socket}
+      end\
+      """
+
+      assert expected == strip_example_source(source)
+    end
+
+    test "annotations are preserved" do
+      source = """
+      defmodule Storybook.Examples.Example do
+        use PhoenixStorybook.Story, :example
+
+        def doc, do: "This is some example."
+
+        @impl Phoenix.LiveView
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      expected = """
+      defmodule Storybook.Examples.Example do
+        use Phoenix.LiveView
+
+        @impl Phoenix.LiveView
+        def render(assigns) do
+          ~H"Hello world!"
+        end
+      end\
+      """
+
+      assert expected == strip_example_source(source)
+    end
+  end
+end


### PR DESCRIPTION
Hi @cblavier! I am creating a PR as I promised.

---

Altering code via regex is very hard and therefore the regexes for stripping `doc` and `extra_sources` functions were not very robust and were stripping wrong pieces of the source code.

I am replacing them with transformation on the AST level. It should be much more robust and hopefully still maintain much of the original formatting (given the original source code was formatted).

Fixes #605