### PR TITLE
Add support for DaisyUI themes 

### DIFF
--- a/assets/js/lib/color_mode_hook.js
+++ b/assets/js/lib/color_mode_hook.js
@@ -13,6 +13,7 @@ export const ColorModeHook = {
   mounted() {
     self = this;
     window.addEventListener("psb-set-color-mode", this.onSetColorMode);
+    document.documentElement.setAttribute('data-theme', this.selectedColorMode());
 
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
       const selectedMode = this.selectedColorMode();
@@ -53,6 +54,7 @@ export const ColorModeHook = {
   },
   onSetColorMode: (e) => {
     const selectedMode = e.detail.mode || "system";
+    document.documentElement.setAttribute('data-theme', selectedMode);
     localStorage.setItem("psb_selected_color_mode", selectedMode);
     const actualMode = self.actualColorMode(selectedMode);
     self.pushEvent("psb-set-color-mode", {


### PR DESCRIPTION
This enables the DaisyUI themes to be toggle-able via Phoenix Storybook mode selector.

Love storybook! keep up the great work. :)

-- Greg
