### PR TITLE
fix: remove stray curly brace

### DIFF
--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -56,7 +56,6 @@
       nonce={csp_nonce(@conn, :style)}
       rel="stylesheet"
       href={asset_path(@conn, "css/phoenix_storybook.css")}
-      }
     />
     <%= if path = storybook_css_path(@conn) do %>
       <style nonce={csp_nonce(@conn, :style)}>


### PR DESCRIPTION
I was investigating why Firefox didn't reload my CSS styles after changing them anymore, and only in the Storybook. Found this instead.