### PR TITLE
add hash to CSS path

### DIFF
--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -60,7 +60,7 @@
     />
     <%= if path = storybook_css_path(@conn) do %>
       <style nonce={csp_nonce(@conn, :style)}>
-        @import "<%= path %>" layer(app);
+        @import "<%= path %>?v=<%= storybook_css_hash(@conn, path) %>" layer(app);
       </style>
     <% end %>
     <style nonce={csp_nonce(@conn, :style)}>

--- a/lib/phoenix_storybook/views/layout_view.ex
+++ b/lib/phoenix_storybook/views/layout_view.ex
@@ -64,6 +64,26 @@ defmodule PhoenixStorybook.LayoutView do
   def storybook_js_path(conn), do: storybook_setting(conn, :js_path)
   def storybook_js_type(conn), do: storybook_setting(conn, :js_script_type, "text/javascript")
 
+  # We append a hash of the CSS file contents to the URL used in the @import
+  # at-rule to ensure cache busting in the development environment.
+  def storybook_css_hash(conn, path) do
+    content =
+      conn
+      |> storybook_setting(:otp_app)
+      |> :code.priv_dir()
+      |> Path.join("/static")
+      |> Path.join(path)
+      |> File.read()
+
+    case content do
+      {:ok, content} ->
+        :md5 |> :crypto.hash(content) |> Base.url_encode64(padding: false)
+
+      {:error, _} ->
+        ""
+    end
+  end
+
   defp title(conn_or_socket), do: storybook_setting(conn_or_socket, :title, "Live Storybook")
 
   defp title_prefix(conn_or_socket) do


### PR DESCRIPTION
This adds the MD5 hash of the CSS file to the import path, which causes Firefox to reload the styles on change.

resolves #652 