### PR TITLE
fix: folder_index callback spec

### DIFF
--- a/lib/phoenix_storybook/stories/index.ex
+++ b/lib/phoenix_storybook/stories/index.ex
@@ -40,7 +40,7 @@ defmodule PhoenixStorybook.Index do
     @callback folder_name() :: nil | String.t()
     @callback folder_icon() :: nil | Icon.t()
     @callback folder_open?() :: boolean()
-    @callback folder_index() :: integer()
+    @callback folder_index() :: nil | integer()
     @callback entry(String.t()) :: keyword(String.t() | Icon.t())
   end
 


### PR DESCRIPTION
The default implementation of `folder_index/0` returns `nil`:

https://github.com/phenixdigital/phoenix_storybook/blob/f9e98e93d07e89f7edaee9eb4682ef98c95185a4/lib/phoenix_storybook/stories/index.ex#L66

Which results in a Dialyzer warning in applications using storybook:

```
storybook/_root.index.exs:5:callback_type_mismatch
Type mismatch for @callback folder_index/0 in PhoenixStorybook.Index.IndexBehaviour behaviour.

Expected type:
integer()

Actual type:
nil
```