### PR TITLE
Make missing asset paths not an error

### DIFF
--- a/lib/phoenix_storybook.ex
+++ b/lib/phoenix_storybook.ex
@@ -262,6 +262,7 @@ defmodule PhoenixStorybook do
 
                   quote do
                     @external_resource unquote(path)
+                    def asset_hash(unquote(asset)), do: nil
                   end
               end
           end


### PR DESCRIPTION
Currently, when an asset is missing you get an error from the template trying to access it, e.g:

<img width="789" height="563" alt="Screenshot 2025-09-05 at 12 03 49" src="https://github.com/user-attachments/assets/36e81352-01d5-4288-b610-efa012ef6e8f" />

Meaning you don't get to see warning, I propose treating this like other missing configuration and just returning `nil` instead.


