### PR TITLE
Namespace JS hooks to prevent silent overrides

### DIFF
--- a/assets/js/lib/warn_reserved_hooks.js
+++ b/assets/js/lib/warn_reserved_hooks.js
@@ -1,0 +1,9 @@
+export function warnReservedHooks(reservedNames, userHooks) {
+  for (const name of Object.keys(userHooks ?? {})) {
+    if (reservedNames.includes(name)) {
+      console.warn(
+        `[phoenix_storybook] Hook "${name}" is reserved by PhoenixStorybook and will be overridden.`,
+      );
+    }
+  }
+}

--- a/assets/js/phoenix_storybook.js
+++ b/assets/js/phoenix_storybook.js
@@ -3,6 +3,7 @@ import { ColorModeHook } from "./lib/color_mode_hook";
 import { SearchHook } from "./lib/search_hook";
 import { SidebarHook } from "./lib/sidebar_hook";
 import { StoryHook } from "./lib/story_hook";
+import { warnReservedHooks } from "./lib/warn_reserved_hooks";
 
 if (window.storybook === undefined) {
   console.warn("No storybook configuration detected.");
@@ -22,14 +23,16 @@ const csrfToken = document.querySelector("meta[name='csrf-token']")?.getAttribut
 const selectedColorMode = ColorModeHook.selectedColorMode();
 const actualColorMode = ColorModeHook.actualColorMode(selectedColorMode);
 
+const psbHooks = {
+  "PhoenixStorybook.StoryHook": StoryHook,
+  "PhoenixStorybook.SearchHook": SearchHook,
+  "PhoenixStorybook.SidebarHook": SidebarHook,
+  "PhoenixStorybook.ColorModeHook": ColorModeHook,
+};
+warnReservedHooks(Object.keys(psbHooks), window.storybook.Hooks);
+
 const liveSocket = new LiveView.LiveSocket(socketPath, Phoenix.Socket, {
-  hooks: {
-    ...window.storybook.Hooks,
-    StoryHook,
-    SearchHook,
-    SidebarHook,
-    ColorModeHook,
-  },
+  hooks: { ...window.storybook.Hooks, ...psbHooks },
   uploaders: window.storybook.Uploaders,
   params: (_liveViewName) => {
     return {

--- a/assets/js/phoenix_storybook_iframe.js
+++ b/assets/js/phoenix_storybook_iframe.js
@@ -1,5 +1,6 @@
 // phoenix and phoenix_live_view are loaded from host app dependencies (see JSAssets module)
 import { ColorModeHook } from "./lib/color_mode_hook";
+import { warnReservedHooks } from "./lib/warn_reserved_hooks";
 
 if (window.storybook === undefined) {
   console.warn("No storybook configuration detected.");
@@ -18,8 +19,13 @@ const csrfToken = window.parent.document
   .querySelector("meta[name='csrf-token']")
   ?.getAttribute("content");
 
+const psbHooks = {
+  "PhoenixStorybook.ColorModeHook": ColorModeHook,
+};
+warnReservedHooks(Object.keys(psbHooks), window.storybook.Hooks);
+
 const liveSocket = new LiveView.LiveSocket(socketPath, Phoenix.Socket, {
-  hooks: { ...window.storybook.Hooks, ColorModeHook },
+  hooks: { ...window.storybook.Hooks, ...psbHooks },
   uploaders: window.storybook.Uploaders,
   params: (_liveViewName) => {
     return {

--- a/lib/phoenix_storybook/live/search.ex
+++ b/lib/phoenix_storybook/live/search.ex
@@ -39,7 +39,7 @@ defmodule PhoenixStorybook.Search do
     ~H"""
     <div
       id="search-container"
-      phx-hook="SearchHook"
+      phx-hook="PhoenixStorybook.SearchHook"
       phx-show={show_container()}
       phx-hide={hide_container()}
       class="psb psb:hidden psb:opacity-0 psb:relative psb:z-10 psb:transition-all"

--- a/lib/phoenix_storybook/live/sidebar.ex
+++ b/lib/phoenix_storybook/live/sidebar.ex
@@ -65,7 +65,7 @@ defmodule PhoenixStorybook.Sidebar do
     ~H"""
     <section
       id="sidebar"
-      phx-hook="SidebarHook"
+      phx-hook="PhoenixStorybook.SidebarHook"
       class="psb psb:text-gray-600 psb:dark:text-slate-400 psb:lg:block psb:fixed psb:z-20 psb:lg:z-auto psb:w-80 psb:lg:w-60 psb:text-base psb:lg:text-sm psb:h-screen psb:flex psb:flex-col psb:flex-grow psb:bg-slate-50 psb:dark:bg-slate-800 psb:lg:pt-20 psb:pb-32 psb:px-4 psb:overflow-y-auto"
     >
       <span id="close-sidebar-icon" phx-update="ignore">

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -226,7 +226,7 @@ defmodule PhoenixStorybook.StoryLive do
     <div
       class="psb psb:space-y-6 psb:pb-12 psb:flex psb:flex-col psb:h-[calc(100vh_-_7rem)] psb:lg:h-[calc(100vh_-_4rem)]"
       id="story-live"
-      phx-hook="StoryHook"
+      phx-hook="PhoenixStorybook.StoryHook"
     >
       <div class="psb">
         <div class="psb psb:flex psb:my-6 psb:items-center">

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -38,7 +38,7 @@
               phx-click-away={
                 JS.hide(to: "#psb-colormode-dropdown", transition: hide_dropdown_transition())
               }
-              phx-hook="ColorModeHook"
+              phx-hook="PhoenixStorybook.ColorModeHook"
               data-selected-mode={@selected_color_mode}
             >
               <div class="psb psb:px-4 psb:py-3">

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -783,7 +783,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
       assert html =~ ~r/defmodule.*TreeStorybook\.Examples\.Example/
       refute html =~ ~r/extra_sources/
       refute html =~ ~r/doc/
-      refute html =~ ~r/PhoenixStorybook/
+      refute html =~ ~r/defmodule.*PhoenixStorybook/
     end
 
     test "renders source permalink icon for main source file", %{conn: conn} do


### PR DESCRIPTION
Addresses Problem 1 from #810  (silent overrides of user hooks).

## Changes

- Register the four LiveView hooks under `PhoenixStorybook.<Name>` keys in `assets/js/phoenix_storybook.js` and `phoenix_storybook_iframe.js`, and warn on startup if `window.storybook.Hooks` defines a key that collides with one of them.
- Each bundle derives its reserved list from its own hook-registration object, so the registered keys are the single source of truth.
- Update four `phx-hook=` attributes to the new keys: `templates/layout/live.html.heex`, `live/story_live.ex`, `live/sidebar.ex`, `live/search.ex`.
- Tighten one refute in `test/phoenix_storybook/live/story_live_test.exs` from `~r/PhoenixStorybook/` to `~r/defmodule.*PhoenixStorybook/` so it no longer trips on the new `phx-hook="PhoenixStorybook.ColorModeHook"` value in the rendered chrome.