### PR TITLE
Prefix PhoenixStorybook UI element ids

### DIFF
--- a/assets/js/lib/search_hook.js
+++ b/assets/js/lib/search_hook.js
@@ -4,10 +4,10 @@ export const SearchHook = {
   },
 
   mounted() {
-    const searchContainer = document.querySelector("#search-container");
-    const searchModal = document.querySelector("#search-modal");
-    const searchList = document.querySelector("#search-list");
-    const searchInput = document.querySelector("#search-input");
+    const searchContainer = document.querySelector("#psb-search-container");
+    const searchModal = document.querySelector("#psb-search-modal");
+    const searchList = document.querySelector("#psb-search-list");
+    const searchInput = document.querySelector("#psb-search-input");
 
     let allStories = searchList.children;
     let firstStory = searchList.firstElementChild;
@@ -68,7 +68,7 @@ export const SearchHook = {
         const link = activeStory.firstElementChild;
 
         this.resetInput(searchInput);
-        this.pushEventTo("#search-container", "navigate", {
+        this.pushEventTo("#psb-search-container", "navigate", {
           path: link.pathname,
         });
         this.dispatchCloseSearch();
@@ -115,7 +115,7 @@ export const SearchHook = {
       const link = activeStory.firstElementChild;
 
       this.resetInput(searchInput);
-      this.pushEventTo("#search-container", "navigate", {
+      this.pushEventTo("#psb-search-container", "navigate", {
         path: link.pathname,
       });
       this.dispatchCloseSearch();
@@ -124,7 +124,7 @@ export const SearchHook = {
 
   resetInput(searchInput) {
     searchInput.value = "";
-    this.pushEventTo("#search-container", "search", { search: { input: "" } });
+    this.pushEventTo("#psb-search-container", "search", { search: { input: "" } });
   },
 
   dispatchOpenSearch() {

--- a/assets/js/lib/sidebar_hook.js
+++ b/assets/js/lib/sidebar_hook.js
@@ -1,7 +1,7 @@
 export const SidebarHook = {
   mounted() {
-    const sidebarContainer = document.querySelector("#sidebar-container");
-    const overlay = document.querySelector("#sidebar-overlay");
+    const sidebarContainer = document.querySelector("#psb-sidebar-container");
+    const overlay = document.querySelector("#psb-sidebar-overlay");
 
     const openSidebar = () => {
       sidebarContainer.classList.remove("psb:hidden");

--- a/assets/js/lib/story_hook.js
+++ b/assets/js/lib/story_hook.js
@@ -4,7 +4,7 @@ export const StoryHook = {
     if (window.location.hash) {
       const el = document.querySelector(window.location.hash);
       if (el) {
-        const liveContainer = document.querySelector("#live-container");
+        const liveContainer = document.querySelector("#psb-live-container");
         setTimeout(() => {
           liveContainer.scrollTop = el.offsetTop - 115;
         }, 100);

--- a/lib/phoenix_storybook/live/search.ex
+++ b/lib/phoenix_storybook/live/search.ex
@@ -38,7 +38,7 @@ defmodule PhoenixStorybook.Search do
   def render(assigns) do
     ~H"""
     <div
-      id="search-container"
+      id="psb-search-container"
       phx-hook="SearchHook"
       phx-show={show_container()}
       phx-hide={hide_container()}
@@ -49,7 +49,7 @@ defmodule PhoenixStorybook.Search do
 
       <div class="psb psb:fixed psb:inset-0 psb:z-10 psb:overflow-y-auto psb:p-4 psb:sm:p-6 psb:md:p-20">
         <div
-          id="search-modal"
+          id="psb-search-modal"
           phx-show={show_modal()}
           phx-hide={hide_modal()}
           phx-click-away={JS.dispatch("psb:close-search")}
@@ -62,7 +62,7 @@ defmodule PhoenixStorybook.Search do
             for={%{}}
             as={:search}
             phx-debounce={500}
-            id="search-form"
+            id="psb-search-form"
             class="psb psb:relative"
           >
             <.fa_icon
@@ -72,7 +72,7 @@ defmodule PhoenixStorybook.Search do
               class="psb:pointer-events-none psb:absolute psb:top-3.5 psb:left-4 psb:h-5 psb:w-5 psb:text-gray-400"
             />
             {text_input(f, :input,
-              id: "search-input",
+              id: "psb-search-input",
               "phx-change": "search",
               "phx-target": @myself,
               placeholder: "Search...",
@@ -89,7 +89,7 @@ defmodule PhoenixStorybook.Search do
           <% end %>
 
           <ul
-            id="search-list"
+            id="psb-search-list"
             class="psb psb:max-h-72 psb:scroll-py-2 psb:divide-y psb:divide-gray-200 psb:dark:divide-slate-600 psb:overflow-y-auto psb:pb-2 psb:text-sm psb:text-gray-800"
           >
             <%= for {story, i} <- Enum.with_index(@stories) do %>
@@ -133,7 +133,7 @@ defmodule PhoenixStorybook.Search do
     JS.show(
       js,
       transition: {"psb:ease-out psb:duration-300", "psb:opacity-0", "psb:opacity-100"},
-      to: "#search-container"
+      to: "#psb-search-container"
     )
   end
 
@@ -141,7 +141,7 @@ defmodule PhoenixStorybook.Search do
     JS.hide(
       js,
       transition: {"psb:ease-in psb:duration-200", "psb:opacity-100", "psb:opacity-0"},
-      to: "#search-container"
+      to: "#psb-search-container"
     )
   end
 
@@ -150,7 +150,7 @@ defmodule PhoenixStorybook.Search do
       js,
       {"psb:ease-out psb:duration-300", "psb:opacity-0 psb:scale-90",
        "psb:opacity-100 psb:scale-100"},
-      to: "#search-modal"
+      to: "#psb-search-modal"
     )
   end
 
@@ -159,7 +159,7 @@ defmodule PhoenixStorybook.Search do
       js,
       {"psb:ease-in psb:duration-200", "psb:opacity-100 psb:scale-100",
        "psb:opacity-0 psb:scale-90"},
-      to: "#search-modal"
+      to: "#psb-search-modal"
     )
   end
 end

--- a/lib/phoenix_storybook/live/sidebar.ex
+++ b/lib/phoenix_storybook/live/sidebar.ex
@@ -64,11 +64,11 @@ defmodule PhoenixStorybook.Sidebar do
   def render(assigns) do
     ~H"""
     <section
-      id="sidebar"
+      id="psb-sidebar"
       phx-hook="SidebarHook"
       class="psb psb:text-gray-600 psb:dark:text-slate-400 psb:lg:block psb:fixed psb:z-20 psb:lg:z-auto psb:w-80 psb:lg:w-60 psb:text-base psb:lg:text-sm psb:h-screen psb:flex psb:flex-col psb:flex-grow psb:bg-slate-50 psb:dark:bg-slate-800 psb:lg:pt-20 psb:pb-32 psb:px-4 psb:overflow-y-auto"
     >
-      <span id="close-sidebar-icon" phx-update="ignore">
+      <span id="psb-close-sidebar-icon" phx-update="ignore">
         <.fa_icon
           style={:regular}
           name="xmark"
@@ -80,7 +80,7 @@ defmodule PhoenixStorybook.Sidebar do
 
       <div class="psb psb:bg-white psb:dark:bg-slate-900 psb:relative psb:pointer-events-auto psb:mb-4">
         <button
-          id="search-button"
+          id="psb-search-button"
           phx-click={JS.dispatch("psb:open-search")}
           class="psb psb:hidden psb:w-full psb:lg:flex psb:items-center psb:text-sm psb:leading-6 psb:text-slate-400 psb:rounded-md psb:border psb:border-1 psb:border-slate-100 psb:dark:border-slate-600 psb:hover:border-slate-200 psb:py-1.5 psb:pl-2 psb:pr-3"
         >

--- a/lib/phoenix_storybook/live/story/component_doc.ex
+++ b/lib/phoenix_storybook/live/story/component_doc.ex
@@ -46,8 +46,8 @@ defmodule PhoenixStorybook.Story.ComponentDoc do
     </div>
     <div :if={@doc && @doc.body && @doc.body != ""}>
       <a
-        phx-click={JS.show(to: "#doc-next") |> JS.hide() |> JS.show(to: "#read-less")}
-        id="read-more"
+        phx-click={JS.show(to: "#psb-doc-next") |> JS.hide() |> JS.show(to: "#psb-read-less")}
+        id="psb-read-more"
         class="psb psb:py-2 psb:inline-block psb:text-slate-400 psb:hover:text-indigo-700 psb:dark:hover:text-sky-400 psb:cursor-pointer"
       >
         <.fa_icon
@@ -58,13 +58,13 @@ defmodule PhoenixStorybook.Story.ComponentDoc do
         /> Read more
       </a>
       <a
-        phx-click={JS.hide(to: "#doc-next") |> JS.hide() |> JS.show(to: "#read-more")}
-        id="read-less"
+        phx-click={JS.hide(to: "#psb-doc-next") |> JS.hide() |> JS.show(to: "#psb-read-more")}
+        id="psb-read-less"
         class="psb psb:pt-2 psb:pb-4 psb:hidden psb:text-slate-400 psb:hover:text-indigo-700 psb:dark:hover:text-sky-400 psb:cursor-pointer"
       >
         <.fa_icon name="caret-down" style={:thin} plan={@fa_plan} class="psb:mr-1" /> Read less
       </a>
-      <div id="doc-next" class="psb:hidden psb:space-y-4 ">
+      <div id="psb-doc-next" class="psb:hidden psb:space-y-4 ">
         <div class="psb psb-doc psb:text-sm psb:md:text-base psb:leading-7 psb:text-slate-700 psb:dark:text-slate-500">
           {raw(@doc.body)}
         </div>

--- a/lib/phoenix_storybook/live/story/playground.ex
+++ b/lib/phoenix_storybook/live/story/playground.ex
@@ -209,7 +209,7 @@ defmodule PhoenixStorybook.Story.Playground do
 
   def render(assigns) do
     ~H"""
-    <div id="playground" class="psb psb:flex psb:flex-col psb:flex-1">
+    <div id="psb-playground" class="psb psb:flex psb:flex-col psb:flex-1">
       {render_upper_navigation_tabs(assigns)}
       {render_upper_tab_content(assigns)}
       {render_lower_navigation_tabs(assigns)}
@@ -718,7 +718,7 @@ defmodule PhoenixStorybook.Story.Playground do
       </.form>
       <SourceSelect.source_file_select
         :if={Enum.any?(@story.merged_attributes())}
-        form_id="variation-selection-form"
+        form_id="psb-variation-selection-form"
         as={:variation}
         field={:variation_id}
         label="Open a variation"

--- a/lib/phoenix_storybook/live/story/playground_preview_live.ex
+++ b/lib/phoenix_storybook/live/story/playground_preview_live.ex
@@ -107,9 +107,9 @@ defmodule PhoenixStorybook.Story.PlaygroundPreviewLive do
       )
 
     ~H"""
-    <div id="playground-preview-live" style="width: 100%; height: 100%;">
+    <div id="psb-playground-preview-live" style="width: 100%; height: 100%;">
       <div
-        id="sandbox"
+        id="psb-playground-sandbox"
         class={[
           LayoutView.sandbox_class(
             @socket,

--- a/lib/phoenix_storybook/live/story/variations.ex
+++ b/lib/phoenix_storybook/live/story/variations.ex
@@ -204,7 +204,7 @@ defmodule PhoenixStorybook.Story.Variations do
 
     ~H"""
     <%= Phoenix.View.render_layout LayoutView, "root_iframe.html", assigns do %>
-      <div id="iframe-container" style={@iframe_opts[:style]} class={@color_mode_class}>
+      <div id="psb-iframe-container" style={@iframe_opts[:style]} class={@color_mode_class}>
         {ComponentRenderer.render(@rendering_context)}
       </div>
     <% end %>

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -204,7 +204,8 @@ defmodule PhoenixStorybook.StoryLive do
     end
   end
 
-  defp close_sidebar(socket), do: push_event(socket, "psb:close-sidebar", %{"id" => "#sidebar"})
+  defp close_sidebar(socket),
+    do: push_event(socket, "psb:close-sidebar", %{"id" => "#psb-sidebar"})
 
   def render(assigns = %{story_load_error: error})
       when not is_nil(error) do
@@ -225,7 +226,7 @@ defmodule PhoenixStorybook.StoryLive do
     ~H"""
     <div
       class="psb psb:space-y-6 psb:pb-12 psb:flex psb:flex-col psb:h-[calc(100vh_-_7rem)] psb:lg:h-[calc(100vh_-_4rem)]"
-      id="story-live"
+      id="psb-story-live"
       phx-hook="StoryHook"
     >
       <div class="psb">
@@ -399,7 +400,7 @@ defmodule PhoenixStorybook.StoryLive do
     ~H"""
     <.live_component
       module={Playground}
-      id="playground"
+      id="psb-playground"
       story={@story}
       story_path={@story_path}
       backend_module={@backend_module}
@@ -737,7 +738,7 @@ defmodule PhoenixStorybook.StoryLive do
       {:set_theme, String.to_atom(theme)}
     )
 
-    send_update(Playground, id: "playground", new_theme: theme)
+    send_update(Playground, id: "psb-playground", new_theme: theme)
     ThemeHelpers.call_theme_function(socket.assigns.backend_module, theme)
 
     {:noreply,
@@ -838,7 +839,7 @@ defmodule PhoenixStorybook.StoryLive do
   end
 
   def handle_info(event_log = %EventLog{view: PlaygroundPreviewLive}, socket) do
-    send_update(Playground, id: "playground", new_event: event_log)
+    send_update(Playground, id: "psb-playground", new_event: event_log)
     {:noreply, socket}
   end
 
@@ -852,12 +853,16 @@ defmodule PhoenixStorybook.StoryLive do
   end
 
   def handle_info({:new_variations_attributes, variations_attributes}, socket) do
-    send_update(Playground, id: "playground", new_variations_attributes: variations_attributes)
+    send_update(Playground,
+      id: "psb-playground",
+      new_variations_attributes: variations_attributes
+    )
+
     {:noreply, socket}
   end
 
   def handle_info({:new_template_attributes, template_attributes}, socket) do
-    send_update(Playground, id: "playground", new_template_attributes: template_attributes)
+    send_update(Playground, id: "psb-playground", new_template_attributes: template_attributes)
     {:noreply, socket}
   end
 

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -17,7 +17,7 @@
               JS.show(to: "#psb-colormode-dropdown", transition: show_dropdown_transition())
             }
           >
-            <div id="color-mode-icon" phx-update="ignore">
+            <div id="psb-color-mode-icon" phx-update="ignore">
               <.fa_icon
                 style={:regular}
                 name={color_mode_icon("light")}
@@ -158,7 +158,7 @@
   </div>
 
   <nav class="psb psb:lg:hidden psb:w-full psb:h-12 psb:border-slate-200 psb:dark:border-slate-600 psb:border-t psb:flex psb:text-gray-600 psb:dark:text-slate-300 psb:items-center psb:cursor-pointer psb:pr-2">
-    <span id="breadcrumb-icon" phx-update="ignore">
+    <span id="psb-breadcrumb-icon" phx-update="ignore">
       <.fa_icon
         name="bars"
         style={:regular}
@@ -174,15 +174,15 @@
 </header>
 
 <div
-  id="sidebar-overlay"
+  id="psb-sidebar-overlay"
   phx-click={JS.dispatch("psb:close-sidebar")}
   class="psb psb:fixed psb:hidden psb:lg:hidden psb:inset-0 psb:z-10 psb:backdrop-blur-sm psb:bg-black/20"
 >
 </div>
 
-<div id="sidebar-container" class="psb psb:hidden psb:lg:block">
+<div id="psb-sidebar-container" class="psb psb:hidden psb:lg:block">
   <.live_component
-    id="sidebar"
+    id="psb-sidebar"
     module={PhoenixStorybook.Sidebar}
     backend_module={@backend_module}
     root_path={@root_path}
@@ -193,14 +193,14 @@
 </div>
 
 <.live_component
-  id="search"
+  id="psb-search"
   module={PhoenixStorybook.Search}
   backend_module={@backend_module}
   root_path={@root_path}
 />
 
 <div
-  id="live-container"
+  id="psb-live-container"
   class={[
     "psb psb:pt-28 psb:lg:pt-16 psb:left-0 psb:lg:left-60 psb:absolute psb:h-[calc(100vh_-_7rem)]",
     "psb:md:h-screen psb:w-full psb:lg:w-[calc(100%_-_15rem)] psb:px-4 psb:lg:px-12 psb:overflow-auto",

--- a/test/phoenix_storybook/live/playground_live_test.exs
+++ b/test/phoenix_storybook/live/playground_live_test.exs
@@ -16,7 +16,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
   describe "simple component with one field" do
     test "renders playground", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "component: hello"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: hello"
     end
 
     test "playground preview is updated as form is changed", %{conn: conn} do
@@ -27,13 +27,13 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
       |> render_change()
 
       wait_for_preview_lv(view)
-      assert view |> element("#playground-preview-live") |> render() =~ "component: world"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: world"
     end
 
     test "renders playground code a simple component", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component?tab=playground")
       view |> element("a", "Code") |> render_click()
-      assert view |> element("#playground pre") |> render() =~ "hello"
+      assert view |> element("#psb-playground pre") |> render() =~ "hello"
     end
 
     test "playground code is updated as form is changed", %{conn: conn} do
@@ -44,36 +44,36 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
       |> form("#tree_storybook_component-playground-form", %{playground: %{label: "world"}})
       |> render_change()
 
-      assert view |> element("#playground pre") |> render() =~ "world"
+      assert view |> element("#psb-playground pre") |> render() =~ "world"
 
       view |> element("a", "Preview") |> render_click()
-      assert view |> element("#playground-preview-live") |> render() =~ "component: world"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: world"
     end
 
     test "we can switch to another variation from the playground", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "component: hello"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: hello"
 
       {:ok, view, _html} =
         view
-        |> element("#variation-selection-form_variation_id")
+        |> element("#psb-variation-selection-form_variation_id")
         |> render_change(%{variation: %{variation_id: "world"}})
         |> follow_redirect(conn)
 
-      assert view |> element("#playground-preview-live") |> render() =~ "component: world"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: world"
     end
 
     test "we can switch to another variation group from the playground", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/a_folder/live_component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "component: hello"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: hello"
 
       {:ok, view, _html} =
         view
-        |> element("#variation-selection-form_variation_id")
+        |> element("#psb-variation-selection-form_variation_id")
         |> render_change(%{variation: %{variation_id: "default"}})
         |> follow_redirect(conn)
 
-      assert view |> element("#playground-preview-live") |> render() =~ "component: hello"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: hello"
     end
 
     test "playground rendered HTML is available", %{conn: conn} do
@@ -84,7 +84,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
       |> form("#tree_storybook_component-playground-form", %{playground: %{label: "world"}})
       |> render_change()
 
-      assert view |> element("#playground pre") |> render() =~ "world"
+      assert view |> element("#psb-playground pre") |> render() =~ "world"
     end
 
     test "playground rendered HTML is unavailable for live_components", %{conn: conn} do
@@ -132,7 +132,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
     test "it shows the component preview", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/b_folder/all_types_component?tab=playground")
 
-      assert view |> element("#playground-preview-live") |> render() =~
+      assert view |> element("#psb-playground-preview-live") |> render() =~
                "all_types_component: default label"
     end
 
@@ -141,7 +141,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
       view |> element("a", "Code") |> render_click()
 
-      assert view |> element("#playground-preview-live") |> render() =~
+      assert view |> element("#psb-playground-preview-live") |> render() =~
                "all_types_component: default label"
 
       assert view |> element("pre.highlight") |> render() =~ ".all_types_component"
@@ -149,14 +149,14 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
     test "component can be updated with a toggle switch", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/b_folder/all_types_component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "toggle: false"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "toggle: false"
       view |> element("button[role=switch]") |> render_click()
-      assert view |> element("#playground-preview-live") |> render() =~ "toggle: true"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "toggle: true"
     end
 
     test "component can be updated with a new integer value", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/b_folder/all_types_component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "index_i: 42"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "index_i: 42"
 
       view
       |> form("#tree_storybook_b_folder_all_types_component-playground-form", %{
@@ -166,12 +166,12 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
       wait_for_preview_lv(view)
 
-      assert view |> element("#playground-preview-live") |> render() =~ "index_i: 37"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "index_i: 37"
     end
 
     test "component can be updated with a new float value", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/b_folder/all_types_component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "index_f: 37.2"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "index_f: 37.2"
 
       view
       |> form("#tree_storybook_b_folder_all_types_component-playground-form", %{
@@ -181,12 +181,12 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
       wait_for_preview_lv(view)
 
-      assert view |> element("#playground-preview-live") |> render() =~ "index_f: 42.1"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "index_f: 42.1"
     end
 
     test "component can be updated with a invalid value", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/b_folder/all_types_component?tab=playground")
-      assert view |> element("#playground-preview-live") |> render() =~ "index_i: 42"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "index_i: 42"
 
       view
       |> form("#tree_storybook_b_folder_all_types_component-playground-form", %{
@@ -196,7 +196,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
       wait_for_preview_lv(view)
 
-      assert view |> element("#playground-preview-live") |> render() =~ "index_i: wrong"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "index_i: wrong"
     end
 
     test "component can be updated by selecting an option", %{conn: conn} do
@@ -210,7 +210,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
       wait_for_preview_lv(view)
 
-      assert view |> element("#playground-preview-live") |> render() =~ "option: opt3"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "option: opt3"
     end
 
     test "required label is still defined in code when empty", %{conn: conn} do
@@ -243,7 +243,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
     test "it shows the component preview", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/a_folder/live_component?tab=playground")
 
-      html = view |> element("#playground-preview-live") |> render()
+      html = view |> element("#psb-playground-preview-live") |> render()
       assert html =~ "component: hello"
       assert html =~ "inner block"
     end
@@ -258,12 +258,12 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
   describe "theme switch in playground" do
     test "component preview is updated as a different theme is selected", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component?tab=playground")
-      html = view |> element("#playground-preview-live") |> render()
+      html = view |> element("#psb-playground-preview-live") |> render()
       assert html =~ ~r|component:\s*hello\s*default|
 
       view |> element("a.psb-theme", "Colorful") |> render_click()
       wait_for_preview_lv(view)
-      html = view |> element("#playground-preview-live") |> render()
+      html = view |> element("#psb-playground-preview-live") |> render()
       assert html =~ ~r|component:\s*hello\s*colorful|
     end
 
@@ -280,7 +280,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
     test "it doees not fail with no theme strategies", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/tree_storybook/component?tab=playground")
-      html = view |> element("#playground-preview-live") |> render()
+      html = view |> element("#psb-playground-preview-live") |> render()
       assert html =~ ~r|component:\s*hello|
       refute html =~ ~r|default|
     end
@@ -290,7 +290,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
     test "component preview is updated as a different color mode is selected", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/component?tab=playground")
 
-      html = view |> element("#playground-preview-live") |> render()
+      html = view |> element("#psb-playground-preview-live") |> render()
       refute html =~ ~s|class="dark"|
       assert html =~ ~r|component:\s*hello\s*default|
 
@@ -299,7 +299,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
       |> render_hook("psb-set-color-mode", %{"selected_mode" => "dark", "mode" => "dark"})
 
       wait_for_preview_lv(view)
-      html = view |> element("#playground-preview-live .psb-sandbox") |> render()
+      html = view |> element("#psb-playground-preview-live .psb-sandbox") |> render()
       [component_class] = html |> LazyHTML.from_fragment() |> LazyHTML.attribute("class")
       assert component_class |> String.split(" ") |> Enum.member?("dark")
       assert html =~ ~r|component:\s*hello\s*default|
@@ -386,7 +386,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
     test "component rendering is updated as template buttons are clicked", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/templates/template_component?tab=playground")
       assert [playground_preview_view] = live_children(view)
-      playground_element = element(playground_preview_view, "#playground-preview-live")
+      playground_element = element(playground_preview_view, "#psb-playground-preview-live")
       assert render(playground_element) =~ "template_component: hello"
 
       playground_preview_view
@@ -429,7 +429,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
     test "playground form is in sync with variations assigns", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/storybook/templates/template_component?tab=playground")
       assert [playground_preview_view] = live_children(view)
-      playground_element = element(playground_preview_view, "#playground-preview-live")
+      playground_element = element(playground_preview_view, "#psb-playground-preview-live")
 
       assert render(playground_element) =~ "template_component: hello"
 
@@ -467,7 +467,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
         live(conn, "/storybook/templates/template_component?tab=playground&variation_id=group")
 
       assert [playground_preview_view] = live_children(view)
-      playground_element = element(playground_preview_view, "#playground-preview-live")
+      playground_element = element(playground_preview_view, "#psb-playground-preview-live")
 
       assert render(playground_element) =~ "template_component: one"
       assert render(playground_element) =~ "template_component: two"
@@ -525,7 +525,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
         )
 
       assert [playground_preview_view] = live_children(view)
-      playground_element = element(playground_preview_view, "#playground-preview-live")
+      playground_element = element(playground_preview_view, "#psb-playground-preview-live")
 
       assert render(playground_element) =~
                "<span>template_component: from_template / status: true</span>"
@@ -554,7 +554,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
         )
 
       assert [playground_preview_view] = live_children(view)
-      playground_element = element(playground_preview_view, "#playground-preview-live")
+      playground_element = element(playground_preview_view, "#psb-playground-preview-live")
       assert render(playground_element) =~ "<div></div>"
     end
 

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -114,26 +114,26 @@ defmodule PhoenixStorybook.StoryLiveTest do
     test "navigate in sidebar", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/component")
 
-      assert view |> element("#sidebar a", "Live Component (root)") |> render_click() =~
+      assert view |> element("#psb-sidebar a", "Live Component (root)") |> render_click() =~
                "LiveComponent first doc paragraph."
 
       # A folder is open
-      refute has_element?(view, "#sidebar a", "Component (a_folder)")
+      refute has_element?(view, "#psb-sidebar a", "Component (a_folder)")
 
       # Opening A folder
-      element(view, "#sidebar div", "A Folder") |> render_click()
-      assert has_element?(view, "#sidebar a", "Component (a_folder)")
+      element(view, "#psb-sidebar div", "A Folder") |> render_click()
+      assert has_element?(view, "#psb-sidebar a", "Component (a_folder)")
 
       # B folder is already open (by its index.exs file)
-      assert has_element?(view, "#sidebar a", "AllTypesComponent (b_folder)")
+      assert has_element?(view, "#psb-sidebar a", "AllTypesComponent (b_folder)")
 
       # reaching items inside
-      assert view |> element("#sidebar a", "AllTypesComponent (b_folder)") |> render_click() =~
+      assert view |> element("#psb-sidebar a", "AllTypesComponent (b_folder)") |> render_click() =~
                "Component mixing any attribute possible types"
 
       # closing "B folder"
-      element(view, "#sidebar div", "Config Name") |> render_click()
-      refute has_element?(view, "#sidebar a", "AllTypesComponent (b_folder)")
+      element(view, "#psb-sidebar div", "Config Name") |> render_click()
+      refute has_element?(view, "#psb-sidebar a", "AllTypesComponent (b_folder)")
     end
 
     test "navigate to unknown tab", %{conn: conn} do
@@ -604,7 +604,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
         ~p"/storybook/component?#{[tab: :playground, theme: :default, variation_id: :hello]}"
       )
 
-      assert view |> element("#playground-preview-live") |> render() =~ "component: hello"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: hello"
 
       view |> element("a", "Stories") |> render_click()
 
@@ -615,7 +615,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
         ~p"/storybook/component?#{[tab: :playground, theme: :default, variation_id: :world]}"
       )
 
-      assert view |> element("#playground-preview-live") |> render() =~ "component: world"
+      assert view |> element("#psb-playground-preview-live") |> render() =~ "component: world"
     end
 
     test "sandbox container is default flex div", %{conn: conn} do
@@ -930,40 +930,40 @@ defmodule PhoenixStorybook.StoryLiveTest do
     test "filters the search list based on user input", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/a_page")
 
-      assert has_element?(view, "#search-container a", "Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (a_folder)")
+      assert has_element?(view, "#psb-search-container a", "Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (a_folder)")
 
       view
-      |> with_target("#search-container")
+      |> with_target("#psb-search-container")
       |> render_change("search", %{"search" => %{"input" => "a_folder"}})
 
-      refute has_element?(view, "#search-container a", "Component (root)")
-      refute has_element?(view, "#search-container a", "Live Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (a_folder)")
+      refute has_element?(view, "#psb-search-container a", "Component (root)")
+      refute has_element?(view, "#psb-search-container a", "Live Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (a_folder)")
     end
 
     test "returns everything on blank input", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/a_page")
 
-      assert has_element?(view, "#search-container a", "Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (a_folder)")
+      assert has_element?(view, "#psb-search-container a", "Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (a_folder)")
 
       view
-      |> with_target("#search-container")
+      |> with_target("#psb-search-container")
       |> render_change("search", %{"search" => %{"input" => ""}})
 
-      assert has_element?(view, "#search-container a", "Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (root)")
-      assert has_element?(view, "#search-container a", "Live Component (a_folder)")
+      assert has_element?(view, "#psb-search-container a", "Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (root)")
+      assert has_element?(view, "#psb-search-container a", "Live Component (a_folder)")
     end
 
     test "navigates to a specified story", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/a_page")
 
       view
-      |> with_target("#search-container")
+      |> with_target("#psb-search-container")
       |> render_change("navigate", %{"path" => ~p"/storybook/component"})
 
       assert_patch(view, ~p"/storybook/component", 200)


### PR DESCRIPTION
Addresses Problem 2 from #810 (bare DOM ids on chrome elements).

## Changes

- Rename 23 static chrome ids to `psb-*` across templates and live components: `sidebar`, `sidebar-container`, `sidebar-overlay`, `close-sidebar-icon`, `search`, `search-button`, `search-container`, `search-modal`, `search-form`, `search-input`, `search-list`, `live-container`, `story-live`, `playground`, `playground-preview-live`, `sandbox` → `psb-playground-sandbox`, `iframe-container`, `color-mode-icon`, `breadcrumb-icon`, `read-more`, `read-less`, `doc-next`, `variation-selection-form`.
- Update internal selectors that target those ids: `JS.toggle/show/hide(to: …)` in `search.ex` and `component_doc.ex`, `push_event` payload in `story_live.ex`, and `document.querySelector(...)` / `pushEventTo(...)` in `assets/js/lib/{sidebar,search,story}_hook.js`.
- Rebind the four `send_update(Playground, id: "playground", …)` callsites in `story_live.ex` (theme switch, event log, variation/template attribute sync) to the new `"psb-playground"` id — otherwise these silently no-op against the renamed component.
- Update existing tests in `story_live_test.exs` and `playground_live_test.exs` to use the new selectors.

## User-visible impact

Breaking for anyone whose custom CSS or scripts target the old chrome ids (`#sidebar`, `#playground`, `#search-modal`, …) to theme or extend the storybook UI. They need to update selectors to the `psb-` names.