### PR TITLE
Align remaining storybook surfaces with psb namespace

### DIFF
--- a/assets/js/lib/color_mode_hook.js
+++ b/assets/js/lib/color_mode_hook.js
@@ -43,7 +43,7 @@ export const ColorModeHook = {
     return "light";
   },
   toggleColorModeClass: (mode) => {
-    if ("colorMode" in document.documentElement.dataset) {
+    if ("psbColorMode" in document.documentElement.dataset) {
       if (mode === "dark") {
         document.documentElement.classList.add("psb:dark");
       } else {

--- a/assets/js/lib/color_mode_hook.js
+++ b/assets/js/lib/color_mode_hook.js
@@ -12,12 +12,12 @@ let self;
 export const ColorModeHook = {
   mounted() {
     self = this;
-    window.addEventListener("psb-set-color-mode", this.onSetColorMode);
+    window.addEventListener("psb:set-color-mode", this.onSetColorMode);
 
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
       const selectedMode = this.selectedColorMode();
       const actualMode = this.actualColorMode(selectedMode);
-      this.pushEvent("psb-set-color-mode", {
+      this.pushEvent("psb:set-color-mode", {
         selected_mode: selectedMode,
         mode: actualMode,
       });
@@ -26,7 +26,7 @@ export const ColorModeHook = {
   },
 
   destroyed() {
-    window.removeEventListener("psb-set-color-mode", this.onSetColorMode);
+    window.removeEventListener("psb:set-color-mode", this.onSetColorMode);
   },
 
   selectedColorMode() {
@@ -55,7 +55,7 @@ export const ColorModeHook = {
     const selectedMode = e.detail.mode || "system";
     localStorage.setItem("psb_selected_color_mode", selectedMode);
     const actualMode = self.actualColorMode(selectedMode);
-    self.pushEvent("psb-set-color-mode", {
+    self.pushEvent("psb:set-color-mode", {
       selected_mode: selectedMode,
       mode: actualMode,
     });

--- a/assets/js/lib/story_hook.js
+++ b/assets/js/lib/story_hook.js
@@ -19,7 +19,7 @@ export const StoryHook = {
     this.bindAnchorLinks();
   },
   bindAnchorLinks() {
-    for (const link of document.querySelectorAll(".variation-anchor-link")) {
+    for (const link of document.querySelectorAll(".psb-variation-anchor-link")) {
       link.addEventListener("click", (event) => {
         event.preventDefault();
         window.history.replaceState({}, "", link.hash);

--- a/lib/phoenix_storybook/live/story/variations.ex
+++ b/lib/phoenix_storybook/live/story/variations.ex
@@ -61,7 +61,7 @@ defmodule PhoenixStorybook.Story.Variations do
         >
           <!-- Variation description -->
           <div class="psb psb:group psb:col-span-5 psb:font-medium psb:hover:font-semibold psb:mb-4 psb:border-b psb:border-slate-100 psb:dark:border-slate-600 psb:md:text-lg psb:leading-7 psb:text-slate-700 psb:dark:text-slate-300 psb:flex psb:justify-between">
-            <%= link to: "##{anchor_id(variation)}", class: "psb variation-anchor-link" do %>
+            <%= link to: "##{anchor_id(variation)}", class: "psb psb-variation-anchor-link" do %>
               <.fa_icon
                 style={:light}
                 name="link"

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -806,7 +806,7 @@ defmodule PhoenixStorybook.StoryLive do
   end
 
   def handle_event(
-        "psb-set-color-mode",
+        "psb:set-color-mode",
         %{"selected_mode" => selected_mode, "mode" => mode},
         socket
       ) do

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -300,7 +300,7 @@ defmodule PhoenixStorybook.StoryLive do
         for={%{}}
         as={:navigation}
         id={"#{Macro.underscore(@story)}-navigation-form"}
-        class="psb story-nav-form psb:lg:hidden"
+        class="psb psb-story-nav-form psb:lg:hidden"
       >
         {select(f, :tab, navigation_select_options(@tabs),
           "phx-change": "psb-set-tab",
@@ -310,7 +310,7 @@ defmodule PhoenixStorybook.StoryLive do
         )}
       </.form>
       <!-- :lg+ version of navigation tabs -->
-      <nav class="psb story-tabs psb:hidden psb:lg:flex psb:rounded-lg psb:border psb:border-gray-300 psb:dark:border-slate-600 psb:bg-slate-100 psb:dark:bg-slate-900 psb:h-10 psb:text-sm psb:font-medium">
+      <nav class="psb psb-story-tabs psb:hidden psb:lg:flex psb:rounded-lg psb:border psb:border-gray-300 psb:dark:border-slate-600 psb:bg-slate-100 psb:dark:bg-slate-900 psb:h-10 psb:text-sm psb:font-medium">
         <%= for tab <- @tabs do %>
           <% {tab_id, tab_label} = {elem(tab, 0), elem(tab, 1)} %>
           <a

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -51,7 +51,7 @@
                 <a
                   :for={mode <- ~w(light dark system)}
                   phx-click={
-                    JS.dispatch("psb-set-color-mode",
+                    JS.dispatch("psb:set-color-mode",
                       to: "#psb-colormode-dropdown",
                       detail: %{mode: mode}
                     )

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -39,7 +39,7 @@
                 JS.hide(to: "#psb-colormode-dropdown", transition: hide_dropdown_transition())
               }
               phx-hook="PhoenixStorybook.ColorModeHook"
-              data-selected-mode={@selected_color_mode}
+              data-psb-selected-mode={@selected_color_mode}
             >
               <div class="psb psb:px-4 psb:py-3">
                 <p class="psb psb:text-sm psb:font-medium psb:text-indigo-600 psb:dark:text-slate-300 psb:text-left">

--- a/lib/phoenix_storybook/templates/layout/root.html.heex
+++ b/lib/phoenix_storybook/templates/layout/root.html.heex
@@ -3,7 +3,7 @@
   lang="en"
   class="psb"
   phx-socket={live_socket_path(@conn)}
-  data-color-mode={color_mode?(@conn)}
+  data-psb-color-mode={color_mode?(@conn)}
 >
   <head>
     <meta charset="utf-8" />

--- a/test/phoenix_storybook/live/playground_live_test.exs
+++ b/test/phoenix_storybook/live/playground_live_test.exs
@@ -296,7 +296,7 @@ defmodule PhoenixStorybook.PlaygroundLiveTest do
 
       view
       |> element("#psb-colormode-dropdown")
-      |> render_hook("psb-set-color-mode", %{"selected_mode" => "dark", "mode" => "dark"})
+      |> render_hook("psb:set-color-mode", %{"selected_mode" => "dark", "mode" => "dark"})
 
       wait_for_preview_lv(view)
       html = view |> element("#psb-playground-preview-live .psb-sandbox") |> render()

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -987,7 +987,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
   end
 
   describe "color mode change" do
-    test "send psb-set-color-mode will change color mode in picker", %{conn: conn} do
+    test "send psb:set-color-mode will change color mode in picker", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/component")
       refute view |> has_element?("#psb-colormode-dropdown[data-selected-mode=dark]")
 
@@ -1000,7 +1000,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
 
       view
       |> element("#psb-colormode-dropdown")
-      |> render_hook("psb-set-color-mode", %{"selected_mode" => "dark", "mode" => "dark"})
+      |> render_hook("psb:set-color-mode", %{"selected_mode" => "dark", "mode" => "dark"})
 
       assert view |> has_element?("#psb-colormode-dropdown[data-selected-mode=dark]")
 
@@ -1012,12 +1012,12 @@ defmodule PhoenixStorybook.StoryLiveTest do
       assert component_class |> String.split(" ") |> Enum.member?("dark")
     end
 
-    test "send psb-set-color-mode applies light sandbox class", %{conn: conn} do
+    test "send psb:set-color-mode applies light sandbox class", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/component")
 
       view
       |> element("#psb-colormode-dropdown")
-      |> render_hook("psb-set-color-mode", %{"selected_mode" => "light", "mode" => "light"})
+      |> render_hook("psb:set-color-mode", %{"selected_mode" => "light", "mode" => "light"})
 
       assert view |> has_element?("#psb-colormode-dropdown[data-selected-mode=light]")
 

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -456,7 +456,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
 
       html =
         view
-        |> element(".story-nav-form select")
+        |> element(".psb-story-nav-form select")
         |> render_change(%{navigation: %{tab: "source"}})
 
       assert_patched(
@@ -754,13 +754,13 @@ defmodule PhoenixStorybook.StoryLiveTest do
     test "renders a page story", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/storybook/a_page")
       assert html =~ "A Page"
-      refute html =~ "story-tabs"
+      refute html =~ "psb-story-tabs"
     end
 
     test "renders a page story with tabs", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/storybook/b_page")
       assert html =~ "B Page: tab_1"
-      assert html =~ "story-tabs"
+      assert html =~ "psb-story-tabs"
 
       html = view |> element("a", "Tab 2") |> render_click()
       assert_patched(view, ~p"/storybook/b_page?#{[tab: :tab_2, theme: :default]}")

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -989,7 +989,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
   describe "color mode change" do
     test "send psb:set-color-mode will change color mode in picker", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/component")
-      refute view |> has_element?("#psb-colormode-dropdown[data-selected-mode=dark]")
+      refute view |> has_element?("#psb-colormode-dropdown[data-psb-selected-mode=dark]")
 
       component_html = view |> element("#hello-component .psb-sandbox") |> render()
 
@@ -1002,7 +1002,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
       |> element("#psb-colormode-dropdown")
       |> render_hook("psb:set-color-mode", %{"selected_mode" => "dark", "mode" => "dark"})
 
-      assert view |> has_element?("#psb-colormode-dropdown[data-selected-mode=dark]")
+      assert view |> has_element?("#psb-colormode-dropdown[data-psb-selected-mode=dark]")
 
       component_html = view |> element("#hello-component .psb-sandbox") |> render()
 
@@ -1019,7 +1019,7 @@ defmodule PhoenixStorybook.StoryLiveTest do
       |> element("#psb-colormode-dropdown")
       |> render_hook("psb:set-color-mode", %{"selected_mode" => "light", "mode" => "light"})
 
-      assert view |> has_element?("#psb-colormode-dropdown[data-selected-mode=light]")
+      assert view |> has_element?("#psb-colormode-dropdown[data-psb-selected-mode=light]")
 
       component_html = view |> element("#hello-component .psb-sandbox") |> render()
 


### PR DESCRIPTION

Addresses the "Other surfaces" section of #810. Split into three commits by surface type.

## Changes

- **Event separator**: rename custom DOM event `psb-set-color-mode` → `psb:set-color-mode` to match the colon convention used by every other `psb:*` event. Touches `color_mode_hook.js`, the `JS.dispatch` in `layout/live.html.heex`, the `handle_event` in `story_live.ex`, and `render_hook` calls in two test files.
- **Data attributes**: `data-color-mode` → `data-psb-color-mode` on `<html>`, `data-selected-mode` → `data-psb-selected-mode` on the color-mode dropdown. Updates the JS dataset read and three test selectors.
- **CSS classes** : `.variation-anchor-link` → `.psb-variation-anchor-link`, `.story-nav-form` → `.psb-story-nav-form`, `.story-tabs` → `.psb-story-tabs`. Updates `story_hook.js` querySelector and matching test refs.

## User-visible impact

Breaking for anyone targeting the old class names, data attributes, or dispatching `psb-set-color-mode` from outside the storybook.
