### PR TITLE
fix: copy-code button

### DIFF
--- a/assets/css/phoenix_storybook.css
+++ b/assets/css/phoenix_storybook.css
@@ -30,17 +30,6 @@
     font-size: 1em;
   }
 
-  .svg-inline--fa.psb {
-    display: var(--fa-display, inline-block);
-    height: 1em;
-    overflow: visible;
-    vertical-align: -0.125em;
-  }
-
-  .svg-inline--fa.psb.psb\:hidden {
-    display: none;
-  }
-
   .psb-sandbox {
     margin: 0;
     font-family: serif, system-ui, sans-serif;

--- a/assets/js/lib/story_hook.js
+++ b/assets/js/lib/story_hook.js
@@ -34,16 +34,17 @@ export const StoryHook = {
 
     window.addEventListener("psb:copy-code", (e) => {
       const button = e.target;
-      const icon = button.querySelector(".svg-inline--fa") || button.querySelector(".fa-copy");
+      this.copyToClipboard(button.nextElementSibling.textContent);
+
+      const icon = button.querySelector(".fa-copy");
+      if (!icon) return;
+
       button.classList.add(...buttonActiveClasses);
       button.classList.remove(...buttonClasses);
       icon.classList.add(iconActiveClass);
       icon.classList.remove(iconClass);
 
-      this.copyToClipboard(button.nextElementSibling.textContent);
-
       setTimeout(() => {
-        const icon = button.querySelector(".svg-inline--fa") || button.querySelector(".fa-copy");
         icon.classList.add(iconClass);
         icon.classList.remove(iconActiveClass);
         button.classList.add(...buttonClasses);


### PR DESCRIPTION
## Summary
- Copy button in story variations (and Playground Code/HTML tabs) was broken: the first click left the icon stuck on the check glyph, and every following click threw `TypeError: Cannot read properties of null (reading 'classList')` in the console.
- Reuse the icon reference inside the handler instead of re-querying it by a class that no longer matched after the click-time swap.
- Move `copyToClipboard` ahead of the icon animation so the actual copy isn't gated on the cosmetic step.
- Drop the now-unused `.svg-inline--fa.psb` CSS rules (FontAwesome stopped emitting that class).

## Test plan
- [ ] Hover the code block in a story variation, click copy — clipboard gets the code, icon flips to check and restores, no console errors.
- [ ] Repeat clicks cycle cleanly.
- [ ] Same checks in Playground Code and HTML tabs.