### PR TITLE
Fix psb: prefix ordering and dark-mode color coverage

### DIFF
--- a/assets/css/imports/welcome_page.css
+++ b/assets/css/imports/welcome_page.css
@@ -3,23 +3,23 @@
 }
 
 .psb-sandbox .psb-welcome-page h1 {
-  @apply psb:text-indigo-700 psb:text-2xl psb:pt-4 psb:mb-2;
+  @apply psb:text-indigo-700 psb:dark:text-sky-400 psb:text-2xl psb:pt-4 psb:mb-2;
 }
 
 .psb-sandbox .psb-welcome-page h2 {
-  @apply psb:text-indigo-700 psb:text-xl psb:pt-4 psb:mb-2;
+  @apply psb:text-indigo-700 psb:dark:text-sky-400 psb:text-xl psb:pt-4 psb:mb-2;
 }
 
 .psb-sandbox .psb-welcome-page h3 {
-  @apply psb:text-slate-500 psb:text-lg psb:pt-4 psb:mb-2 psb:font-bold;
+  @apply psb:text-slate-500 psb:dark:text-slate-300 psb:text-lg psb:pt-4 psb:mb-2 psb:font-bold;
 }
 
 .psb-sandbox .psb-welcome-page p {
-  @apply psb:md:text-lg psb:leading-6 psb:md:leading-8 psb:text-slate-500 psb:w-full psb:text-left psb:mb-4 psb:mt-2;
+  @apply psb:md:text-lg psb:leading-6 psb:md:leading-8 psb:text-slate-500 psb:dark:text-slate-300 psb:w-full psb:text-left psb:mb-4 psb:mt-2;
 }
 
 .psb-sandbox .psb-welcome-page strong {
-  @apply psb:text-indigo-700;
+  @apply psb:text-indigo-700 psb:dark:text-sky-400;
 }
 
 .psb-sandbox .psb-welcome-page ul {
@@ -27,7 +27,7 @@
 }
 
 .psb-sandbox .psb-welcome-page ul li {
-  @apply psb:text-lg psb:text-slate-500;
+  @apply psb:text-lg psb:text-slate-500 psb:dark:text-slate-300;
 }
 
 .psb-sandbox .psb-welcome-page code.inline {

--- a/lib/phoenix_storybook/live/sidebar.ex
+++ b/lib/phoenix_storybook/live/sidebar.ex
@@ -137,12 +137,12 @@ defmodule PhoenixStorybook.Sidebar do
                 <%= if folder_icon do %>
                   <.user_icon
                     icon={folder_icon}
-                    class="fa-fw psb:-ml-1 psb:mr-1.5 psb:group-hover:text-indigo-600 dark:psb:group-hover:text-sky-400"
+                    class="fa-fw psb:-ml-1 psb:mr-1.5 psb:group-hover:text-indigo-600 psb:dark:group-hover:text-sky-400"
                     fa_plan={@fa_plan}
                   />
                 <% end %>
 
-                <span class="psb psb:group-hover:text-indigo-600 dark:psb:group-hover:text-sky-400">
+                <span class="psb psb:group-hover:text-indigo-600 psb:dark:group-hover:text-sky-400">
                   {name}
                 </span>
               </div>
@@ -162,13 +162,13 @@ defmodule PhoenixStorybook.Sidebar do
                 <%= if icon do %>
                   <.user_icon
                     icon={icon}
-                    class="fa-fw psb:-ml-1 psb:mr-1.5 psb:group-hover:text-indigo-600 dark:psb:group-hover:text-sky-400"
+                    class="fa-fw psb:-ml-1 psb:mr-1.5 psb:group-hover:text-indigo-600 psb:dark:group-hover:text-sky-400"
                     fa_plan={@fa_plan}
                   />
                 <% end %>
                 <.link
                   patch={if t = assigns[:theme], do: "#{story_path}?theme=#{t}", else: story_path}
-                  class="psb psb:block psb:w-full psb:py-2 psb:lg:py-1 psb:group-hover:text-indigo-600 dark:psb:group-hover:text-sky-400"
+                  class="psb psb:block psb:w-full psb:py-2 psb:lg:py-1 psb:group-hover:text-indigo-600 psb:dark:group-hover:text-sky-400"
                 >
                   {name}
                 </.link>

--- a/lib/phoenix_storybook/live/sidebar.ex
+++ b/lib/phoenix_storybook/live/sidebar.ex
@@ -100,7 +100,7 @@ defmodule PhoenixStorybook.Sidebar do
         {render_entries(assign(assigns, entries: @content_tree, folder_path: @root_path, root: true))}
       </nav>
 
-      <div class="psb psb:hidden psb:lg:block psb:fixed psb:bottom-3 psb:left-0 psb:w-60 psb:text-md psb:text-center psb:text-slate-400 psb:hover:text-indigo-600 psb:hover:font-bold">
+      <div class="psb psb:hidden psb:lg:block psb:fixed psb:bottom-3 psb:left-0 psb:w-60 psb:text-md psb:text-center psb:text-slate-400 psb:hover:text-indigo-600 psb:dark:hover:text-sky-400 psb:hover:font-bold">
         <%= link to: "https://github.com/phenixdigital/phoenix_storybook", target: "_blank", class: "psb" do %>
           <.fa_icon style={:brands} name="github" plan={:pro} />
           - {Application.spec(:phoenix_storybook, :vsn)}
@@ -200,7 +200,7 @@ defmodule PhoenixStorybook.Sidebar do
 
   defp story_class(current_path, story_path) do
     story_class =
-      "psb psb:flex psb:items-center psb:-ml-[12px] psb:block psb:border-l psb:pl-4 psb:hover:border-indigo-600 psb:hover:text-indigo-600 psb:hover:border-l-1.5 psb:group"
+      "psb psb:flex psb:items-center psb:-ml-[12px] psb:block psb:border-l psb:pl-4 psb:hover:border-indigo-600 psb:dark:hover:border-sky-400 psb:hover:text-indigo-600 psb:dark:hover:text-sky-400 psb:hover:border-l-1.5 psb:group"
 
     if current_path == story_path do
       story_class <>

--- a/lib/phoenix_storybook/live/story/playground.ex
+++ b/lib/phoenix_storybook/live/story/playground.ex
@@ -954,7 +954,7 @@ defmodule PhoenixStorybook.Story.Playground do
   value: "[Multiple values]",
   disabled: true,
   class:
-    "psb psb:form-input psb:cursor-not-allowed psb:block psb:w-full psb:shadow-sm psb:focus:ring-indigo-500 psb:focus:border-indigo-500 psb:text-xs psb:md:text-sm psb:bg-gray-100 psb:dark:bg-slate-800 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md psb:dark:text-slate-500"
+    "psb psb:form-input psb:cursor-not-allowed psb:block psb:w-full psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:text-xs psb:md:text-sm psb:bg-gray-100 psb:dark:bg-slate-800 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md psb:dark:text-slate-500"
 )}|
 
           {:eval, value} ->
@@ -972,7 +972,7 @@ defmodule PhoenixStorybook.Story.Playground do
   value: inspect(@value),
   disabled: true,
   class:
-    "psb psb:form-input psb:cursor-not-allowed psb:block psb:w-full psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:dark:focus:border-sky-400 psb:text-xs psb:md:text-sm psb:bg-gray-100 psb:dark:bg-slate-800 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md psb:dark:text-slate-500"
+    "psb psb:form-input psb:cursor-not-allowed psb:block psb:w-full psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:text-xs psb:md:text-sm psb:bg-gray-100 psb:dark:bg-slate-800 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md psb:dark:text-slate-500"
 )}|
     end
   end
@@ -1012,7 +1012,7 @@ defmodule PhoenixStorybook.Story.Playground do
       value: @value,
       step: @step,
       class:
-        "psb psb:form-input psb:text-xs psb:md:text-sm psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:dark:focus:ring-sky-400 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md"
+        "psb psb:form-input psb:text-xs psb:md:text-sm psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md"
     )}
     """
   end
@@ -1026,7 +1026,7 @@ defmodule PhoenixStorybook.Story.Playground do
       min: @min,
       max: @max,
       class:
-        "psb psb:form-input psb:text-xs psb:md:text-sm psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:dark:focus:ring-sky-400 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md"
+        "psb psb:form-input psb:text-xs psb:md:text-sm psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md"
     )}
     """
   end
@@ -1036,7 +1036,7 @@ defmodule PhoenixStorybook.Story.Playground do
     {text_input(@form, @attr_id,
       value: @value,
       class:
-        "psb psb:form-input psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:dark:focus:ring-sky-400 psb:border-gray-300 psb:dark:border-slate-600 psb:text-xs psb:md:text-sm psb:rounded-md"
+        "psb psb:form-input psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:border-gray-300 psb:dark:border-slate-600 psb:text-xs psb:md:text-sm psb:rounded-md"
     )}
     """
   end
@@ -1056,7 +1056,7 @@ defmodule PhoenixStorybook.Story.Playground do
       value: @value,
       disabled: true,
       class:
-        "psb psb:cursor-not-allowed psb:bg-gray-100 psb:form-input psb:block psb:w-full psb:dark:text-slate-500 psb:dark:bg-slate-800 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:dark:focus:ring-sky-400 psb:border-gray-300 psb:dark:border-slate-600 psb:text-xs psb:md:text-sm psb:rounded-md"
+        "psb psb:cursor-not-allowed psb:bg-gray-100 psb:form-input psb:block psb:w-full psb:dark:text-slate-500 psb:dark:bg-slate-800 psb:shadow-sm psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:border-gray-300 psb:dark:border-slate-600 psb:text-xs psb:md:text-sm psb:rounded-md"
     )}
     """
   end
@@ -1068,7 +1068,7 @@ defmodule PhoenixStorybook.Story.Playground do
     {select(@form, @attr_id, @values,
       value: @value,
       class:
-        "psb psb:form-select psb:mt-1 psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:pl-3 psb:pr-10 psb:py-2 psb:text-xs psb:md:text-sm psb:focus:outline-none psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:dark:focus:ring-sky-400 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md"
+        "psb psb:form-select psb:mt-1 psb:block psb:w-full psb:dark:text-slate-300 psb:dark:bg-slate-700 psb:pl-3 psb:pr-10 psb:py-2 psb:text-xs psb:md:text-sm psb:focus:outline-none psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400 psb:focus:border-indigo-500 psb:border-gray-300 psb:dark:border-slate-600 psb:rounded-md"
     )}
     """
   end

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -351,11 +351,11 @@ defmodule PhoenixStorybook.StoryLive do
               <%= if icon do %>
                 <.user_icon
                   icon={icon}
-                  class={"psb:lg:mr-2 psb:group-hover:text-indigo-600 dark:psb:group-hover:text-sky-400 #{active_text(@tab, tab_id)}"}
+                  class={"psb:lg:mr-2 psb:group-hover:text-indigo-600 psb:dark:group-hover:text-sky-400 #{active_text(@tab, tab_id)}"}
                   fa_plan={@fa_plan}
                 />
               <% end %>
-              <span class={"psb psb:whitespace-nowrap psb:group-hover:text-indigo-600 dark:psb:group-hover:text-sky-400 #{active_text(@tab, tab_id)}"}>
+              <span class={"psb psb:whitespace-nowrap psb:group-hover:text-indigo-600 psb:dark:group-hover:text-sky-400 #{active_text(@tab, tab_id)}"}>
                 {tab_label}
               </span>
             </span>

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -151,7 +151,7 @@
     <button
       type="button"
       phx-click={JS.dispatch("psb:open-search")}
-      class="psb psb:h-7 psb:w-7 psb:bg-gray-100 psb:dark:bg-gray-600 psb:rounded-full psb:flex psb:flex-row psb:justify-center psb:items-center psb:text-gray-400 psb:hover:text-indigo-600 psb:dark:hover:text-gray-200 psb:focus:outline-none psb:focus:ring-2 psb:focus:ring-offset-2 psb:focus:ring-offset-gray-100 psb:focus:ring-indigo-500"
+      class="psb psb:h-7 psb:w-7 psb:bg-gray-100 psb:dark:bg-gray-600 psb:rounded-full psb:flex psb:flex-row psb:justify-center psb:items-center psb:text-gray-400 psb:hover:text-indigo-600 psb:dark:hover:text-sky-400 psb:focus:outline-none psb:focus:ring-2 psb:focus:ring-offset-2 psb:focus:ring-offset-gray-100 psb:focus:ring-indigo-500 psb:dark:focus:ring-sky-400"
     >
       <.fa_icon name="magnifying-glass" style={:light} plan={@fa_plan} />
     </button>

--- a/priv/templates/phx.gen.storybook/welcome.story.exs
+++ b/priv/templates/phx.gen.storybook/welcome.story.exs
@@ -54,7 +54,7 @@ defmodule Storybook.MyPage do
     ~H"""
     <p class="psb:md:text-lg psb:leading-relaxed psb:text-slate-400 psb:w-full psb:text-left psb:mb-4 psb:mt-2 psb:italic">
       <a
-        class="psb:hover:text-indigo-700"
+        class="psb:hover:text-indigo-700 psb:dark:hover:text-sky-400"
         href={"https://hexdocs.pm/phoenix_storybook/#{@guide}.html"}
         target="_blank"
       >
@@ -74,12 +74,12 @@ defmodule Storybook.MyPage do
         <dl class="psb:sm:divide-y psb:sm:divide-gray-200">
           <%= for {dt, link} <- @items do %>
             <div class="psb:py-4 psb:sm:grid psb:sm:grid-cols-3 psb:sm:gap-4 psb:sm:py-5 psb:sm:px-6 psb:max-w-full">
-              <dt class="psb:text-base psb:font-medium psb:text-indigo-700">
+              <dt class="psb:text-base psb:font-medium psb:text-indigo-700 psb:dark:text-sky-400">
                 {dt}
               </dt>
               <dd class="psb:mt-1 psb:text-base psb:text-slate-400 psb:sm:col-span-2 psb:sm:mt-0 psb:group psb:cursor-pointer psb:max-w-full">
                 <a
-                  class="psb:group-hover:text-indigo-700 psb:max-w-full psb:inline-block psb:truncate"
+                  class="psb:group-hover:text-indigo-700 psb:dark:group-hover:text-sky-400 psb:max-w-full psb:inline-block psb:truncate"
                   href={link}
                   target="_blank"
                 >

--- a/priv/templates/phx.gen.storybook/welcome.story.exs
+++ b/priv/templates/phx.gen.storybook/welcome.story.exs
@@ -21,7 +21,7 @@ defmodule Storybook.MyPage do
     <div class="psb-welcome-page">
       <p>
         We generated your storybook with an example of a page and a component.
-        Explore the generated <code class="psb:inline">*.story.exs</code>
+        Explore the generated <code class="inline">*.story.exs</code>
         files in your <code class="inline">/storybook</code>
         directory. When you're ready to add your own, just drop your new story & index files into the same directory and refresh your storybook.
       </p>
@@ -54,14 +54,14 @@ defmodule Storybook.MyPage do
     ~H"""
     <p class="psb:md:text-lg psb:leading-relaxed psb:text-slate-400 psb:w-full psb:text-left psb:mb-4 psb:mt-2 psb:italic">
       <a
-        class="hover:text-indigo-700"
+        class="psb:hover:text-indigo-700"
         href={"https://hexdocs.pm/phoenix_storybook/#{@guide}.html"}
         target="_blank"
       >
         This and other guides are also available on HexDocs.
       </a>
     </p>
-    <div class="psb:welcome-page psb:border-t psb:border-gray-200 psb:pt-4">
+    <div class="psb-welcome-page psb:border-t psb:border-gray-200 psb:pt-4">
       {Phoenix.HTML.raw(@guide_content)}
     </div>
     """


### PR DESCRIPTION
## What changed

Three focused fixes to phoenix_storybook's dark-mode styling:

**1. `psb:` prefix ordering on dark hover classes** — six classes were written `dark:psb:group-hover:…`. Tailwind v4 requires the prefix first (`psb:dark:…`); as written they emit no CSS, so the sidebar and story-tab hover colors never applied in dark mode. (`sidebar.ex`, `story_live.ex`)

**2. Welcome page template classes** (`phx.gen.storybook/welcome.story.exs`)
- `psb:inline` → `inline` — the styled inline-code look comes from the Earmark `code.inline` hook; `psb:inline` was just `display:inline` (a no-op on `<code>`), leaving one code span unstyled.
- `psb:welcome-page` → `psb-welcome-page` — the custom hook is hyphenated; the colon form parsed as a nonexistent utility and dropped the wrapper styling.
- added the missing `psb:` prefix on the HexDocs link.

**3. Dark-mode `sky` accents** — added `dark:…sky-400` (and `dark:text-slate-300` for low-contrast body text) to elements that stayed indigo/low-contrast in dark mode: sidebar footer + active items, story tabs, the mobile search toggle, welcome-page headings/links, and playground/search controls. Inputs keep their indigo focus border (the brighter outline) intentionally.