### PR TITLE
fix: preserve current theme when navigating from search

### DIFF
--- a/assets/js/lib/search_hook.js
+++ b/assets/js/lib/search_hook.js
@@ -65,13 +65,9 @@ export const SearchHook = {
     searchContainer.addEventListener("keydown", (e) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        const link = activeStory.firstElementChild;
-
-        this.resetInput(searchInput);
-        this.pushEventTo("#psb-search-container", "navigate", {
-          path: link.pathname,
-        });
-        this.dispatchCloseSearch();
+        // Navigation lives on the row's <a patch>; clicking it patches and
+        // bubbles to the cleanup listener below.
+        activeStory.querySelector("a")?.click();
       }
 
       if (e.key === "Escape") {
@@ -111,13 +107,12 @@ export const SearchHook = {
       }
     });
 
-    searchList.addEventListener("click", (_e) => {
-      const link = activeStory.firstElementChild;
+    searchList.addEventListener("click", (e) => {
+      // The row's <a patch> handles navigation itself; we only reset the input
+      // and close the palette once a story link is actually clicked.
+      if (!e.target.closest("a")) return;
 
       this.resetInput(searchInput);
-      this.pushEventTo("#psb-search-container", "navigate", {
-        path: link.pathname,
-      });
       this.dispatchCloseSearch();
     });
   },

--- a/lib/phoenix_storybook/helpers/navigation_helpers.ex
+++ b/lib/phoenix_storybook/helpers/navigation_helpers.ex
@@ -18,6 +18,15 @@ defmodule PhoenixStorybook.NavigationHelpers do
     build_path(root_path, story_path, query)
   end
 
+  def path_to_story(root_path, story_path, params \\ %{}) do
+    query =
+      params
+      |> Map.new()
+      |> Enum.reject(fn {_k, v} -> v in [nil, ""] end)
+
+    build_path(root_path, story_path, query)
+  end
+
   def path_to_iframe(%{assigns: assigns}, root_path, story_path, params) do
     query = build_query(assigns, params)
 

--- a/lib/phoenix_storybook/live/search.ex
+++ b/lib/phoenix_storybook/live/search.ex
@@ -4,6 +4,7 @@ defmodule PhoenixStorybook.Search do
 
   alias Phoenix.LiveView.JS
   alias PhoenixStorybook.LayoutView
+  alias PhoenixStorybook.NavigationHelpers
   alias PhoenixStorybook.SearchHelpers
 
   def mount(socket) do
@@ -16,14 +17,11 @@ defmodule PhoenixStorybook.Search do
     {:ok,
      socket
      |> assign(assigns)
+     |> assign_new(:theme, fn -> nil end)
      |> assign(:show, false)
      |> assign(:all_stories, stories)
      |> assign(:stories, stories)
      |> assign(:fa_plan, backend_module.config(:font_awesome_plan, :free))}
-  end
-
-  def handle_event("navigate", %{"path" => path}, socket) do
-    {:noreply, push_patch(socket, to: path)}
   end
 
   def handle_event("search", %{"search" => %{"input" => ""}}, socket) do
@@ -105,21 +103,22 @@ defmodule PhoenixStorybook.Search do
                     "psb:bg-slate-50 psb:dark:bg-slate-700 psb:text-indigo-600 psb:dark:text-sky-400"
                   )
                 }
-                class="psb psb:flex psb:justify-between psb:group psb:select-none psb:px-4 psb:py-4 psb:space-x-4 psb:cursor-pointer psb:hover:bg-slate-50 psb:dark:hover:bg-slate-700"
+                class="psb psb:group psb:select-none psb:cursor-pointer psb:hover:bg-slate-50 psb:dark:hover:bg-slate-700"
                 tabindex="-1"
-                phx-click={JS.navigate(Path.join(@root_path, story.path))}
               >
                 <.link
-                  patch={Path.join(@root_path, story.path)}
-                  class="psb psb:font-semibold psb:whitespace-nowrap psb:dark:text-slate-300"
+                  patch={NavigationHelpers.path_to_story(@root_path, story.path, %{theme: @theme})}
+                  class="psb psb:flex psb:justify-between psb:px-4 psb:py-4 psb:space-x-4"
                 >
-                  {story.name}
+                  <span class="psb psb:font-semibold psb:whitespace-nowrap psb:dark:text-slate-300">
+                    {story.name}
+                  </span>
+                  <div class="psb psb:truncate">
+                    {LayoutView.render_breadcrumb(@socket, story.path,
+                      span_class: "psb:text-xs psb:dark:text-slate-300"
+                    )}
+                  </div>
                 </.link>
-                <div class="psb psb:truncate">
-                  {LayoutView.render_breadcrumb(@socket, story.path,
-                    span_class: "psb:text-xs psb:dark:text-slate-300"
-                  )}
-                </div>
               </li>
             <% end %>
           </ul>

--- a/lib/phoenix_storybook/templates/layout/live.html.heex
+++ b/lib/phoenix_storybook/templates/layout/live.html.heex
@@ -197,6 +197,7 @@
   module={PhoenixStorybook.Search}
   backend_module={@backend_module}
   root_path={@root_path}
+  theme={assigns[:theme]}
 />
 
 <div

--- a/test/phoenix_storybook/live/story_live_test.exs
+++ b/test/phoenix_storybook/live/story_live_test.exs
@@ -963,14 +963,22 @@ defmodule PhoenixStorybook.StoryLiveTest do
       assert has_element?(view, "#psb-search-container a", "Live Component (a_folder)")
     end
 
-    test "navigates to a specified story", %{conn: conn} do
+    test "links to a specified story carrying the default theme", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/storybook/a_page")
 
-      view
-      |> with_target("#psb-search-container")
-      |> render_change("navigate", %{"path" => ~p"/storybook/component"})
+      assert has_element?(
+               view,
+               ~s|#psb-search-container a[href="/storybook/component?theme=default"]|
+             )
+    end
 
-      assert_patch(view, ~p"/storybook/component", 200)
+    test "search list links carry the active theme", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/storybook/a_page?#{[theme: :colorful]}")
+
+      assert has_element?(
+               view,
+               ~s|#psb-search-container a[href="/storybook/component?theme=colorful"]|
+             )
     end
   end
 


### PR DESCRIPTION
Fixes #816.

Search (Cmd-K) results now carry the active theme through navigation, so selecting a story keeps the current theme.

## Changes
- Each search result is now a single `<a patch>` row whose href is built with the active theme via a new `NavigationHelpers.path_to_story/3`.
- Consolidated navigation onto that link: removed the duplicate `phx-click={JS.navigate}` on the row and the server `handle_event("navigate")`. The JS hook now triggers the link on Enter, and the click listener only resets and closes the palette.
- As a side effect this fixes a latent bug: after filtering, clicking a result could navigate to the highlighted row rather than the clicked one, because the old click listener used the stale highlighted element.

## path_to_story/3
Like `path_to/4`, but query params are passed explicitly instead of being derived from socket assigns — so a caller carries only what it passes (here, the theme, without leaking the previous story's tab/variation).

## Tests
Search tests now assert the rendered links carry the theme (both the default and an active non-default theme).