### PR TITLE
fix: restore @tailwindcss/forms plugin (psb:form-input/select)

### DIFF
--- a/assets/css/phoenix_storybook.css
+++ b/assets/css/phoenix_storybook.css
@@ -10,6 +10,10 @@
 @source "../../lib/**/*.{ex,heex}";
 @source "../../priv/templates/**/*.{eex,exs}";
 
+@plugin '@tailwindcss/forms' {
+  strategy: class;
+}
+
 @custom-variant dark (&:where(.psb\:dark, .psb\:dark *));
 
 @layer utilities {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
         "@tailwindcss/cli": "^4.3.0",
+        "@tailwindcss/forms": "^0.5.11",
         "esbuild": "^0.28.0",
         "npm-run-all": "^4.1.5",
         "phoenix": "file:../deps/phoenix",
@@ -999,6 +1000,19 @@
       },
       "bin": {
         "tailwindcss": "dist/index.mjs"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
+      "integrity": "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -2299,6 +2313,16 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3232,6 +3256,15 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "@tailwindcss/forms": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
+      "integrity": "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==",
+      "dev": true,
+      "requires": {
+        "mini-svg-data-uri": "^1.2.3"
+      }
+    },
     "@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -4050,6 +4083,12 @@
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
+    },
+    "mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
     "@tailwindcss/cli": "^4.3.0",
+    "@tailwindcss/forms": "^0.5.11",
     "esbuild": "^0.28.0",
     "npm-run-all": "^4.1.5",
     "phoenix": "file:../deps/phoenix",


### PR DESCRIPTION
## Changes
- Re-add the `@plugin '@tailwindcss/forms' { strategy: class }` directive to `assets/css/phoenix_storybook.css`.
- Re-add `@tailwindcss/forms` (`^0.5.11`) as a dev dependency.

With `strategy: class` the plugin generates the `psb:form-input` / `psb:form-select` classes that are already referenced across the UI, so those controls get their padding, border, focus ring and select chevron back.

`@tailwindcss/forms` is not deprecated and is Tailwind v4-compatible.

Affected controls:
- playground attribute inputs — `lib/phoenix_storybook/live/story/playground.ex`
- mobile tab-navigation select — `lib/phoenix_storybook/live/story_live.ex:335`
- source-file select — `lib/phoenix_storybook/live/story/source_select.ex:32`

Closes #818