### PR TITLE
feat: open displayed source file in editor

### DIFF
--- a/guides/setup.md
+++ b/guides/setup.md
@@ -206,6 +206,18 @@ defp aliases do
 end
 ```
 
+### f. Open source files in your editor (optional)
+
+When the storybook runs locally, the **Source** tab shows a button that opens the displayed file directly in your editor. It is driven by the `PLUG_EDITOR` environment variable — the same one `Plug.Debugger` and `phoenix_live_reload` use, so you may already have it set. Point it at your editor's URL scheme using the `__FILE__` and `__LINE__` placeholders:
+
+```bash
+export PLUG_EDITOR="vscode://file/__FILE__:__LINE__"   # VS Code
+# export PLUG_EDITOR="cursor://file/__FILE__:__LINE__" # Cursor
+# export PLUG_EDITOR="zed://file/__FILE__:__LINE__"    # Zed
+```
+
+The button only appears when `PLUG_EDITOR` is set. Because it links to an absolute path on the machine running the server, keep it set in your local shell only — not in deployed environments.
+
 ## 5. Update your Docker image
 
 If you are deploying your app with Docker, then you need to copy the storybook content into your

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -420,6 +420,7 @@ defmodule PhoenixStorybook.StoryLive do
         change_event="psb-set-source-file"
         class="psb psb:flex psb:flex-col psb:md:flex-row psb:space-y-1 psb:md:space-x-2 psb:justify-end psb:w-full psb:mb-2"
       />
+      <.editor_button :if={@editor_url} editor_url={@editor_url} />
       <.git_buttons :if={@source_permalink_url} source_permalink_url={@source_permalink_url} />
     </.source_panel>
     """
@@ -506,6 +507,7 @@ defmodule PhoenixStorybook.StoryLive do
         change_event="psb-set-source-file"
         class="psb psb:flex psb:flex-col psb:md:flex-row psb:space-y-1 psb:md:space-x-2 psb:justify-end psb:w-full psb:mb-2"
       />
+      <.editor_button :if={@editor_url} editor_url={@editor_url} />
       <.git_buttons :if={@source_permalink_url} source_permalink_url={@source_permalink_url} />
     </.source_panel>
     """
@@ -580,6 +582,20 @@ defmodule PhoenixStorybook.StoryLive do
     end
   end
 
+  attr :editor_url, :string, required: true
+
+  defp editor_button(assigns) do
+    ~H"""
+    <a
+      href={@editor_url}
+      title="Open in editor"
+      class="psb psb:dark:text-slate-400 psb:dark:hover:text-slate-500"
+    >
+      <i class="fa-solid fa-file-code fa-xl psb:h-5.5 psb:w-5.5"></i>
+    </a>
+    """
+  end
+
   defp assign_source_panel_values(assigns) do
     extra_sources = story_extra_sources(assigns.story)
     extra_sources_file_paths = story_extra_sources_file_paths(assigns.story)
@@ -594,11 +610,14 @@ defmodule PhoenixStorybook.StoryLive do
         extra_sources_file_paths
       )
 
+    editor_url = editor_url(assigns.story, selected_source_file, extra_sources_file_paths)
+
     assign(assigns,
       source: source,
       extra_sources: extra_sources,
       selected_source_file: selected_source_file,
-      source_permalink_url: source_permalink_url
+      source_permalink_url: source_permalink_url,
+      editor_url: editor_url
     )
   end
 
@@ -692,6 +711,43 @@ defmodule PhoenixStorybook.StoryLive do
 
       relative_path ->
         normalized_base_url <> "/" <> relative_path <> line_fragment
+    end
+  end
+
+  defp editor_url(story, selected_source_file, extra_sources_file_paths) do
+    case System.get_env("PLUG_EDITOR") do
+      template when is_binary(template) and template != "" ->
+        build_editor_url(template, story, selected_source_file, extra_sources_file_paths)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp build_editor_url(template, story, selected_source_file, extra_sources_file_paths) do
+    with path when not is_nil(path) <-
+           selected_source_file_path(story, selected_source_file, extra_sources_file_paths),
+         path = to_string(path),
+         true <- path != "" do
+      line = editor_url_line(story, selected_source_file)
+
+      template
+      |> String.replace("__FILE__", URI.encode(path))
+      |> String.replace("__LINE__", to_string(line))
+    else
+      _ -> nil
+    end
+  end
+
+  defp editor_url_line(story, selected_source_file) do
+    if selected_source_file in [nil, ""] and story.storybook_type() == :component and
+         story.render_source() == :function do
+      case StorySource.function_source_line_range(story.function()) do
+        {start_line, _end_line} -> start_line
+        _ -> 1
+      end
+    else
+      1
     end
   end
 

--- a/test/phoenix_storybook/live/story_live_open_in_editor_test.exs
+++ b/test/phoenix_storybook/live/story_live_open_in_editor_test.exs
@@ -1,0 +1,74 @@
+defmodule PhoenixStorybook.StoryLiveOpenInEditorTest do
+  # async: false — these tests mutate the process-global PLUG_EDITOR env var.
+  use ExUnit.Case, async: false
+
+  @endpoint PhoenixStorybook.StoryLiveTestEndpoint
+  @moduletag :capture_log
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  use Phoenix.VerifiedRoutes, endpoint: @endpoint, router: PhoenixStorybook.TestRouter
+
+  @editor "vscode://file/__FILE__:__LINE__"
+
+  setup_all do
+    case start_supervised(@endpoint) do
+      {:ok, _} -> :ok
+      {:error, {:already_started, _}} -> :ok
+    end
+
+    {:ok, conn: build_conn()}
+  end
+
+  setup do
+    System.delete_env("PLUG_EDITOR")
+    on_exit(fn -> System.delete_env("PLUG_EDITOR") end)
+  end
+
+  test "renders open-in-editor button pointing at the example source file", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", @editor)
+
+    {:ok, view, _html} = live(conn, ~p"/storybook/examples/example")
+    view |> element("a", "Source") |> render_click()
+
+    assert has_element?(
+             view,
+             "a[title='Open in editor'][href^='vscode://file/']" <>
+               "[href$='/examples/example.story.exs:1'] i.fa-solid.fa-file-code"
+           )
+  end
+
+  test "uses the component module path and function line for component stories", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", @editor)
+
+    {:ok, view, _html} = live(conn, ~p"/storybook/a_folder/component")
+    html = view |> element("a", "Source") |> render_click()
+
+    [_, href] = Regex.run(~r/href="(vscode:\/\/file\/[^"]+)"/, html)
+    assert href =~ ~r|/component\.ex:4$|
+  end
+
+  test "updates the editor path when selecting an extra source", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", @editor)
+
+    {:ok, view, _html} = live(conn, ~p"/storybook/examples/example")
+    view |> element("a", "Source") |> render_click()
+
+    view
+    |> element("form[id$='-source-selection-form'] select")
+    |> render_change(%{source: %{file: "./templates/example.html.heex"}})
+
+    assert has_element?(
+             view,
+             "a[title='Open in editor'][href$='/examples/templates/example.html.heex:1']"
+           )
+  end
+
+  test "does not render open-in-editor button when PLUG_EDITOR is unset", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/storybook/examples/example")
+    view |> element("a", "Source") |> render_click()
+
+    refute has_element?(view, "a[title='Open in editor']")
+  end
+end

--- a/test/phoenix_storybook/live/story_live_open_in_editor_test.exs
+++ b/test/phoenix_storybook/live/story_live_open_in_editor_test.exs
@@ -65,7 +65,52 @@ defmodule PhoenixStorybook.StoryLiveOpenInEditorTest do
            )
   end
 
+  test "uses line 1 for components rendered from module source", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", @editor)
+
+    {:ok, view, _html} = live(conn, ~p"/storybook/component")
+    view |> element("a", "Source") |> render_click()
+
+    assert has_element?(
+             view,
+             "a[title='Open in editor'][href^='vscode://file/']" <>
+               "[href$='/components/component.ex:1']"
+           )
+  end
+
+  test "uses the component module path and line 1 for live_component stories", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", @editor)
+
+    {:ok, view, _html} = live(conn, ~p"/storybook/live_component")
+    view |> element("a", "Source") |> render_click()
+
+    assert has_element?(
+             view,
+             "a[title='Open in editor'][href^='vscode://file/']" <>
+               "[href$='/components/live_component.ex:1']"
+           )
+  end
+
+  test "substitutes __FILE__ and __LINE__ for any editor template", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", "txmt://open?url=file://__FILE__&line=__LINE__")
+
+    {:ok, view, _html} = live(conn, ~p"/storybook/a_folder/component")
+    html = view |> element("a", "Source") |> render_click()
+
+    [_, href] = Regex.run(~r/href="(txmt:\/\/open[^"]+)"/, html)
+    assert href =~ ~r|file://.+/components/component\.ex&amp;line=4$|
+  end
+
   test "does not render open-in-editor button when PLUG_EDITOR is unset", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/storybook/examples/example")
+    view |> element("a", "Source") |> render_click()
+
+    refute has_element?(view, "a[title='Open in editor']")
+  end
+
+  test "does not render open-in-editor button when PLUG_EDITOR is an empty string", %{conn: conn} do
+    System.put_env("PLUG_EDITOR", "")
+
     {:ok, view, _html} = live(conn, ~p"/storybook/examples/example")
     view |> element("a", "Source") |> render_click()
 


### PR DESCRIPTION
Closes #770.

Adds an "open in editor" button to the **Source** tab. Clicking it opens the file currently shown in the panel — the story, the component module, or whichever extra source is selected — straight in your editor.

The button uses `PLUG_EDITOR`, the same environment variable [`phoenix_live_reload`](https://github.com/phoenixframework/phoenix_live_reload#jumping-to-heex-function-definitions) already relies on for jump-to-source, so anyone who has it set gets the feature for free. It appears only when `PLUG_EDITOR` is present, and `setup.md` documents how to configure it.

### Open questions

For **function-component** stories the link currently jumps to the function's `@doc` line rather than the `def` itself. I have a follow-up that lands exactly on the `def` line. Worth adding, or is the `@doc` line good enough? Happy to fold it in either way.

Should the button be restricted to localhost only, since it links to a path on the server's filesystem? I can add that here, or leave it as a follow-up.
