### PR TITLE
Fix mix compile warnings

### DIFF
--- a/lib/phoenix_storybook/entries.ex
+++ b/lib/phoenix_storybook/entries.ex
@@ -20,8 +20,6 @@ defmodule PhoenixStorybook.Entries do
   alias PhoenixStorybook.ExsCompiler
   alias PhoenixStorybook.{FolderEntry, IndexEntry, StoryEntry}
 
-  require Logger
-
   def story_file_suffix, do: ".story.exs"
   def index_file_suffix, do: ".index.exs"
 

--- a/lib/phoenix_storybook/live/story/playground.ex
+++ b/lib/phoenix_storybook/live/story/playground.ex
@@ -1086,10 +1086,6 @@ defmodule PhoenixStorybook.Story.Playground do
     """
   end
 
-  defp attr_input(assigns = %{values: values}) when not is_nil(values) do
-    attr_input(%{assigns | values: values})
-  end
-
   defp on_toggle_click(attr_id, value) do
     JS.push("playground-toggle", value: %{toggled: [attr_id, !value]})
   end

--- a/lib/phoenix_storybook/live/story/playground_preview_live.ex
+++ b/lib/phoenix_storybook/live/story/playground_preview_live.ex
@@ -62,7 +62,7 @@ defmodule PhoenixStorybook.Story.PlaygroundPreviewLive do
         assign_variations_attributes(socket, group, vars)
 
       _ ->
-        assign_variations_attributes(socket, nil, [])
+        assign(socket, variation: nil, variation_id: nil, variations_attributes: %{})
     end
   end
 

--- a/lib/phoenix_storybook/live/story/playground_preview_live.ex
+++ b/lib/phoenix_storybook/live/story/playground_preview_live.ex
@@ -70,7 +70,7 @@ defmodule PhoenixStorybook.Story.PlaygroundPreviewLive do
     assign(
       socket,
       variation: variation_or_group,
-      variation_id: if(variation_or_group, do: variation_or_group.id, else: nil),
+      variation_id: variation_or_group.id,
       variations_attributes:
         for variation <- variations, into: %{} do
           {variation_id(variation_or_group, variation.id),

--- a/test/phoenix_storybook/stories/story_source_test.exs
+++ b/test/phoenix_storybook/stories/story_source_test.exs
@@ -212,8 +212,8 @@ defmodule PhoenixStorybook.Stories.StorySourceTest do
     test "returns a 1-based range for a component function" do
       {:ok, story} = TreeStorybook.load_story("/component")
       assert {start_line, end_line} = StorySource.function_source_line_range(story.function())
-      assert is_integer(start_line) and start_line > 0
-      assert is_integer(end_line) and end_line >= start_line
+      assert start_line > 0
+      assert end_line >= start_line
     end
   end
 

--- a/test/phoenix_storybook/stories/variation_test.exs
+++ b/test/phoenix_storybook/stories/variation_test.exs
@@ -184,26 +184,16 @@ defmodule PhoenixStorybook.Stories.VariationTest do
         note: "Test note"
       }
 
-      case variation do
-        %Variation{id: id, note: note} when not is_nil(note) ->
-          assert id == :test
-          assert note == "Test note"
-
-        _ ->
-          flunk("Should match variation with note")
-      end
+      %Variation{id: id, note: note} = variation
+      assert id == :test
+      assert note == "Test note"
     end
 
     test "can pattern match on variation without note" do
       variation = %Variation{id: :test}
 
-      case variation do
-        %Variation{id: id, note: nil} ->
-          assert id == :test
-
-        _ ->
-          flunk("Should match variation without note")
-      end
+      %Variation{id: id, note: nil} = variation
+      assert id == :test
     end
 
     test "can pattern match on variation group with note" do
@@ -213,14 +203,9 @@ defmodule PhoenixStorybook.Stories.VariationTest do
         variations: [%Variation{id: :test}]
       }
 
-      case group do
-        %VariationGroup{id: id, note: note} when not is_nil(note) ->
-          assert id == :test_group
-          assert note == "Group note"
-
-        _ ->
-          flunk("Should match variation group with note")
-      end
+      %VariationGroup{id: id, note: note} = group
+      assert id == :test_group
+      assert note == "Group note"
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes warnings from Elixir 1.20's gradual typing found via `mix compile --warnings-as-errors`
- Removes an unused `Logger` require, a nil-forwarding call whose type didn't match the inferred spec, and a dead duplicate function clause
- Cleans up two related dead-code warnings surfaced in tests (an unreachable `case` branch and a redundant `is_integer` check)

## Test plan
- [x] `mix compile --force --warnings-as-errors` is clean
- [x] `mix test` passes (546 tests), no warnings