### PR TITLE
Compute host asset hashes at runtime instead of compile time

### DIFF
--- a/lib/phoenix_storybook.ex
+++ b/lib/phoenix_storybook.ex
@@ -50,8 +50,6 @@ defmodule PhoenixStorybook do
   alias PhoenixStorybook.ExsCompiler
   alias PhoenixStorybook.Stories.StoryValidator
 
-  require Logger
-
   @doc false
   defmacro __using__(opts) do
     if enabled?() do
@@ -220,55 +218,31 @@ defmodule PhoenixStorybook do
     end
   end
 
-  # This quote triggers MD5 calculation for js/css assets provided by the user
+  # Defines asset_hash/1 for the js/css assets provided by the user.
+  # These assets may not exist when the backend module is compiled (asset
+  # pipelines run separately from `mix compile`), so their hashes are
+  # computed at runtime (see PhoenixStorybook.AssetHelpers).
   defp assets_quotes(opts) do
     otp_app = Keyword.get(opts, :otp_app)
 
-    case :code.priv_dir(otp_app) do
-      {:error, :bad_name} ->
-        if Mix.env() != :test,
-          do: Logger.warning("Can't resolve priv dir for application #{otp_app}")
-
-        quote do
-          def asset_hash(_), do: nil
-        end
-
-      priv_dir ->
-        assets_path = Path.join(priv_dir, "/static")
-
-        for asset <- [:css_path, :js_path] do
-          case Keyword.get(opts, asset) do
-            nil ->
-              quote do
-                def asset_hash(unquote(asset)), do: nil
-              end
-
-            asset_path ->
-              path = Path.join(assets_path, asset_path)
-
-              case File.read(path) do
-                {:ok, content} ->
-                  hash = Base.encode16(:crypto.hash(:md5, content), case: :lower)
-
-                  quote do
-                    @external_resource unquote(path)
-                    def asset_hash(unquote(asset)) do
-                      unquote(hash)
-                    end
-                  end
-
-                _ ->
-                  Logger.warning(
-                    "Can't resolve #{asset}: #{path} not found (storybook assets are built by `mix assets.build`)"
-                  )
-
-                  quote do
-                    @external_resource unquote(path)
-                    def asset_hash(unquote(asset)), do: nil
-                  end
-              end
+    for asset <- [:css_path, :js_path] do
+      case Keyword.get(opts, asset) do
+        nil ->
+          quote do
+            def asset_hash(unquote(asset)), do: nil
           end
-        end
+
+        asset_path ->
+          quote do
+            def asset_hash(unquote(asset)) do
+              PhoenixStorybook.AssetHelpers.asset_hash(
+                unquote(otp_app),
+                unquote(asset),
+                unquote(asset_path)
+              )
+            end
+          end
+      end
     end
   end
 

--- a/lib/phoenix_storybook/helpers/asset_helpers.ex
+++ b/lib/phoenix_storybook/helpers/asset_helpers.ex
@@ -1,6 +1,64 @@
 defmodule PhoenixStorybook.AssetHelpers do
   @moduledoc false
 
+  require Logger
+
+  # MD5 hash of a js/css asset provided by the host application (`:css_path` /
+  # `:js_path` options), used as a cache-busting query param by the storybook
+  # layout.
+  #
+  # These assets may not exist when the backend module is compiled (asset
+  # pipelines run separately from `mix compile`), so hashes are computed at
+  # runtime. The hash is cached in `:persistent_term` and revalidated on each
+  # call with a File.stat — mtime + size, as Plug.Static does for ETags — so
+  # the file is never re-read or re-hashed per render, while assets rebuilt
+  # under a running server (e.g. by dev watchers) pick up a fresh hash
+  # automatically.
+  def asset_hash(otp_app, asset, asset_path) do
+    case :code.priv_dir(otp_app) do
+      {:error, :bad_name} ->
+        Logger.warning("Can't resolve priv dir for application #{otp_app}")
+        nil
+
+      priv_dir ->
+        path = priv_dir |> Path.join("static") |> Path.join(asset_path)
+
+        case File.stat(path, time: :posix) do
+          {:ok, %File.Stat{mtime: mtime, size: size}} ->
+            key = {__MODULE__, otp_app, asset_path}
+
+            case :persistent_term.get(key, nil) do
+              {^mtime, ^size, hash} -> hash
+              _ -> compute_asset_hash(key, path, asset, mtime, size)
+            end
+
+          {:error, _} ->
+            warn_missing_asset(asset, path)
+            nil
+        end
+    end
+  end
+
+  defp compute_asset_hash(key, path, asset, mtime, size) do
+    case File.read(path) do
+      {:ok, content} ->
+        hash = Base.encode16(:crypto.hash(:md5, content), case: :lower)
+        :persistent_term.put(key, {mtime, size, hash})
+        hash
+
+      # the file was removed between stat and read
+      {:error, _} ->
+        warn_missing_asset(asset, path)
+        nil
+    end
+  end
+
+  defp warn_missing_asset(asset, path) do
+    Logger.warning(
+      "Can't resolve #{asset}: #{path} not found (storybook assets are built by `mix assets.build`)"
+    )
+  end
+
   def parse_manifest(manifest_path) do
     with {:ok, manifest_json} <- File.read(manifest_path),
          {:ok, manifest_body} <- Jason.decode(manifest_json) do

--- a/test/phoenix_storybook/helpers/asset_helpers_test.exs
+++ b/test/phoenix_storybook/helpers/asset_helpers_test.exs
@@ -1,7 +1,32 @@
 defmodule PhoenixStorybook.AssetHelpersTest do
-  use ExUnit.Case, async: true
+  # async: false — the asset_hash tests share global :persistent_term state
+  # and write scratch files under this library's priv/static.
+  use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
   import PhoenixStorybook.AssetHelpers
+
+  alias PhoenixStorybook.AssetHelpers
+
+  # Any file shipped in this library's priv/static works as a stand-in for a
+  # host application asset — only its bytes matter for the hash.
+  @existing_asset "favicon/favicon.ico"
+  @missing_asset "js/missing.js"
+  @scratch_asset "asset_helpers_test_scratch.css"
+
+  defmodule HashedAssetsStorybook do
+    use PhoenixStorybook,
+      otp_app: :phoenix_storybook,
+      content_path: Path.expand("../../fixtures/storybook_content/empty_files", __DIR__),
+      css_path: "favicon/favicon.ico",
+      js_path: "js/missing.js"
+  end
+
+  defmodule NoAssetsStorybook do
+    use PhoenixStorybook,
+      otp_app: :phoenix_storybook,
+      content_path: Path.expand("../../fixtures/storybook_content/empty_files", __DIR__)
+  end
 
   describe "parse_manifest/2" do
     test "it parses a valid manifest" do
@@ -40,6 +65,134 @@ defmodule PhoenixStorybook.AssetHelpersTest do
       assert_raise RuntimeError, "cannot find asset js/wrong.js in manifest", fn ->
         asset_file_name(manifest, "js/wrong.js")
       end
+    end
+  end
+
+  describe "asset_hash/3" do
+    setup :reset_asset_hash_state
+    setup :create_scratch_asset
+
+    test "computes the md5 hash of the asset and caches it with its stat", %{path: path} do
+      hash = asset_hash(:phoenix_storybook, :css_path, @scratch_asset)
+
+      assert hash == md5(File.read!(path))
+
+      assert {_mtime, _size, ^hash} =
+               :persistent_term.get({AssetHelpers, :phoenix_storybook, @scratch_asset})
+    end
+
+    test "returns the cached hash while mtime and size are unchanged", %{path: path} do
+      %File.Stat{mtime: mtime, size: size} = File.stat!(path, time: :posix)
+
+      hash = asset_hash(:phoenix_storybook, :css_path, @scratch_asset)
+
+      # same byte size and a forced identical mtime: the stat revalidation
+      # cannot tell the file changed, so the cached hash is served
+      File.write!(path, String.duplicate("B", size))
+      File.touch!(path, mtime)
+
+      assert asset_hash(:phoenix_storybook, :css_path, @scratch_asset) == hash
+    end
+
+    test "recomputes the hash when the asset is rebuilt", %{path: path} do
+      hash = asset_hash(:phoenix_storybook, :css_path, @scratch_asset)
+
+      File.write!(path, "body { color: blue }")
+      %File.Stat{mtime: mtime} = File.stat!(path, time: :posix)
+      File.touch!(path, mtime + 1)
+
+      new_hash = asset_hash(:phoenix_storybook, :css_path, @scratch_asset)
+
+      assert new_hash == md5("body { color: blue }")
+      refute new_hash == hash
+    end
+
+    test "does not cache failed lookups" do
+      log =
+        capture_log(fn ->
+          assert asset_hash(:phoenix_storybook, :js_path, @missing_asset) == nil
+        end)
+
+      assert log =~ "Can't resolve js_path"
+
+      assert :persistent_term.get({AssetHelpers, :phoenix_storybook, @missing_asset}, :none) ==
+               :none
+    end
+
+    test "returns nil and warns when the otp_app has no priv dir" do
+      log =
+        capture_log(fn ->
+          assert asset_hash(:unknown_app, :css_path, "app.css") == nil
+        end)
+
+      assert log =~ "Can't resolve priv dir for application unknown_app"
+    end
+  end
+
+  describe "generated asset_hash/1" do
+    setup :reset_asset_hash_state
+
+    test "returns the md5 hash of an existing asset, computed at runtime" do
+      assert HashedAssetsStorybook.asset_hash(:css_path) == expected_hash()
+    end
+
+    test "returns nil and warns when the asset file is missing" do
+      {result, log} = with_log(fn -> HashedAssetsStorybook.asset_hash(:js_path) end)
+
+      assert result == nil
+      assert log =~ "Can't resolve js_path"
+    end
+
+    test "returns nil when no asset path is configured" do
+      assert NoAssetsStorybook.asset_hash(:css_path) == nil
+      assert NoAssetsStorybook.asset_hash(:js_path) == nil
+    end
+
+    test "does not record user assets as external resources" do
+      resources =
+        HashedAssetsStorybook.__info__(:attributes)
+        |> Keyword.get_values(:external_resource)
+        |> List.flatten()
+
+      refute Enum.any?(resources, fn resource ->
+               String.ends_with?(to_string(resource), [@existing_asset, @missing_asset])
+             end)
+    end
+  end
+
+  defp expected_hash do
+    content =
+      [:code.priv_dir(:phoenix_storybook), "static", @existing_asset]
+      |> Path.join()
+      |> File.read!()
+
+    Base.encode16(:crypto.hash(:md5, content), case: :lower)
+  end
+
+  defp reset_asset_hash_state(_context) do
+    clear_asset_hash_cache()
+    on_exit(&clear_asset_hash_cache/0)
+    :ok
+  end
+
+  defp create_scratch_asset(_context) do
+    path =
+      [:code.priv_dir(:phoenix_storybook), "static", @scratch_asset]
+      |> Path.join()
+
+    File.write!(path, "body { color: red }")
+    on_exit(fn -> File.rm(path) end)
+
+    {:ok, path: path}
+  end
+
+  defp md5(content) do
+    Base.encode16(:crypto.hash(:md5, content), case: :lower)
+  end
+
+  defp clear_asset_hash_cache do
+    for {key, _value} <- :persistent_term.get(), match?({AssetHelpers, _, _}, key) do
+      :persistent_term.erase(key)
     end
   end
 


### PR DESCRIPTION
Fixes #860

## What

`use PhoenixStorybook` with `:css_path` / `:js_path` used to compute the asset MD5 hashes (the `?hash=` cache-busting query params) at compile time, recording the files as `@external_resource` of the backend module — including when they don't exist yet. Since host assets are built by pipelines that run separately from `mix compile`, any build that doesn't recompile after producing the assets ships a permanently-stale backend module: every subsequent `mix` invocation recompiles it plus all transitive compile-time dependents (host router included — ~70 files in our app, in every CI container). Details in #860.

This PR computes the hash lazily at runtime instead:

- cached in `:persistent_term` after the first call, so it is **never recomputed per render** (the constraint from #665)
- revalidated on each call with a single `File.stat` — mtime + size, the same signal [`Plug.Static` uses for its default ETags](https://github.com/elixir-plug/plug/blob/v1.20.3/lib/plug/static.ex#L405-L414) — so assets rebuilt under a running server (dev watchers) pick up a fresh hash automatically, with no new config option

## Behavior

Unchanged apart from the staleness fix: same hash values, same warnings for missing files / unresolvable priv dir, same `nil` fallbacks (the layout already renders no query param for `nil`). No new public API. Compile output no longer depends on whether an untracked build artifact existed at compile time.

The known trade-off of stat-based revalidation (a rebuild landing within mtime granularity with identical byte size keeps the cached hash) is the same one `Plug.Static` ETags accept for serving these files, and is covered by an explicit test documenting it as intentional.

## Tests

- hash correctness (computed at runtime, matches file content)
- cache hit while mtime+size unchanged / recompute on rebuild
- failed lookups are not cached; missing file and bad otp_app warn and return `nil`
- generated backend modules no longer record user assets as `@external_resource`

`mix test` (555 tests) and `mix credo --strict` are green.