### PR TITLE
Support for relative content_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 >   more of my free time to fixing bugs and developing new features 🤗
 
 ## v1.4.0 (not released yet)
+- **bugfix**: relative `:content_path` values are resolved from the Mix project cwd at runtime
 - **bugfix**: fixed source permalink generation for selected absolute `extra_sources`, including JS files in production/release environments
 
 ## v1.3.0 (2026-07-03)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ defmodule MyAppWeb.Storybook do
     # OTP name of your application.
     otp_app: :my_app,
 
-    # Path to your storybook stories (required).
+    # Path to your storybook stories (required). Absolute, or relative to the Mix
+    # project root.
     content_path: Path.expand("../../storybook", __DIR__),
 
     # Path to your JS asset, which will be loaded just before PhoenixStorybook's own

--- a/guides/setup.md
+++ b/guides/setup.md
@@ -31,6 +31,7 @@ defmodule MyAppWeb.Storybook do
   use PhoenixStorybook,
     otp_app: :my_app,
     content_path: Path.expand("../../storybook", __DIR__),
+    # Or a Mix-project-relative path: content_path: "storybook",
     # assets path are remote path, not local file-system paths
     css_path: "/assets/css/storybook.css",
     js_path: "/assets/js/storybook.js",

--- a/lib/phoenix_storybook.ex
+++ b/lib/phoenix_storybook.ex
@@ -82,12 +82,17 @@ defmodule PhoenixStorybook do
       @impl PhoenixStorybook.BackendBehaviour
       def storybook_path(story_module) do
         if Code.ensure_loaded?(story_module) do
-          content_path = Keyword.get(unquote(opts), :content_path)
+          content_path =
+            unquote(opts)
+            |> Keyword.get(:content_path)
+            |> Path.expand()
 
-          file_path =
+          Path.join(
+            "/",
             story_module.__file_path__()
-            |> String.replace_prefix(content_path, "")
+            |> Path.relative_to(content_path)
             |> String.replace_suffix(Entries.story_file_suffix(), "")
+          )
         end
       end
     end

--- a/lib/phoenix_storybook/live/story_live.ex
+++ b/lib/phoenix_storybook/live/story_live.ex
@@ -870,7 +870,7 @@ defmodule PhoenixStorybook.StoryLive do
   defp source_file_path_from_content_path(_source_file_path, nil), do: nil
 
   defp source_file_path_from_content_path(source_file_path, content_path) do
-    content_path = to_string(content_path)
+    content_path = content_path |> to_string() |> Path.expand()
 
     with :absolute <- Path.type(content_path),
          common_root when common_root not in [nil, "/", source_file_path] <-

--- a/test/phoenix_storybook_test.exs
+++ b/test/phoenix_storybook_test.exs
@@ -114,5 +114,18 @@ defmodule PhoenixStorybookTest do
       {:ok, module} = TreeStorybook.load_story(path)
       assert TreeStorybook.storybook_path(module) == path
     end
+
+    test "relative content_path maps stories the same as an expanded path" do
+      defmodule RelativeContentStorybook do
+        use Elixir.PhoenixStorybook,
+          otp_app: :phoenix_storybook,
+          content_path: "test/fixtures/storybook_content/tree",
+          compilation_mode: :lazy
+      end
+
+      path = "/a_folder/component"
+      {:ok, module} = RelativeContentStorybook.load_story(path)
+      assert RelativeContentStorybook.storybook_path(module) == path
+    end
   end
 end


### PR DESCRIPTION
`storybook_path/1` does `String.replace_prefix` against `content_path`, which only works if that path is an absolute prefix of `__file_path__()`. That's why the docs tell you to `Path.expand(..., __DIR__)` — and why the compile-time checkout gets baked into the beam.

A relative path like `"storybook"` already works for discovery and lazy compile. This just expands it at runtime and uses `Path.relative_to/2` so breadcrumbs and source permalinks work too. Absolute paths are unchanged.

I hit this reusing `_build` across git worktrees (`check_cwd: false`). The cloned beam kept loading stories from the original tree. Relative `content_path` fixes that without recompiling the backend module.

`Path.relative_to/2` has been around since Elixir 1.0, so we are good there, as this library requires `~> 1.15`.