### PR TITLE
Prevent event logs tab from collapsing

### DIFF
--- a/lib/phoenix_storybook/live/story/playground.ex
+++ b/lib/phoenix_storybook/live/story/playground.ex
@@ -749,7 +749,7 @@ defmodule PhoenixStorybook.Story.Playground do
   defp render_event_logs_tab(assigns) do
     ~H"""
     <div class={[
-      "psb psb:flex psb:flex-col psb:grow psb:py-2 psb:relative",
+      "psb psb:flex psb:flex-col psb:grow psb:py-2 psb:relative psb:min-h-32",
       @lower_tab != :events && "psb:hidden"
     ]}>
       <div


### PR DESCRIPTION
### Problem

* When previewing a tall component in the playground, the preview container expands to fit the component. As a result, the event log pane would get squashed or collapsed entirely, making events invisible and impossible to scroll.

* https://daisy-ui-components-site.fly.dev/storybook/components/sidebar?tab=playground&variation_id=simple_sidebar
<img width="2559" height="210" alt="image" src="https://github.com/user-attachments/assets/244617eb-3483-41ac-865d-710c038ad490" />

### Solution
* This PR enforces a minimum height on the events log tab.
<img width="411" height="337" alt="image" src="https://github.com/user-attachments/assets/ad768a55-bc45-4cff-a562-2c4e3e37592b" />

### checklist
* passes all existing tests
* verified on different viewports. (mobile, tab, desktops)